### PR TITLE
docs: add 2026-04-15 security audit report

### DIFF
--- a/docs/AUDIT-2026-04-15.md
+++ b/docs/AUDIT-2026-04-15.md
@@ -1,0 +1,174 @@
+# ProxyGW 安全审计报告（2026-04-15）
+
+## 审计范围
+
+- 后端 API 与认证逻辑（`backend/*.go`）
+- 部署与服务运行配置（`scripts/install.sh`、`systemd/proxygw.service`）
+- 文档中的安全基线描述（`README.md`）
+
+## 审计方法
+
+- 人工静态代码审查（认证、命令执行、更新链路、配置读写）
+- 最小回归测试执行：`go test ./...`
+
+---
+
+## 结论摘要
+
+当前项目已具备一定安全基础（如密码哈希、参数化 SQL、对下载版本号做了格式校验），但仍存在**高风险供应链问题**与**中风险认证/运维暴露面**。优先建议先修复“更新包完整性校验缺失”和“后台以 root 直接运行”两项。
+
+### 风险分布
+
+- 高风险：2 项
+- 中风险：4 项
+- 低风险：2 项
+
+---
+
+## 详细发现
+
+### 1) [高] 更新链路缺少签名/哈希校验（供应链风险）
+
+**证据**
+- 后端通过 `wget` 直接下载 Xray 压缩包并安装，未校验签名或校验和。见 `backend/update_routes.go`。
+- GeoData 也直接从远端下载后覆盖本地文件，未做完整性校验。见 `backend/update_routes.go`。
+
+**风险**
+- 若下载源、DNS 或网络链路被劫持，可能导致恶意二进制或规则文件落地并以高权限执行。
+
+**建议**
+1. 引入发布方签名验证（优先，如 GPG/minisign/cosign）。
+2. 至少引入 SHA-256 白名单校验（版本->哈希映射）。
+3. 更新失败时保持“原版本运行且告警”，并保留审计日志。
+
+---
+
+### 2) [高] 服务默认以 root 运行，且具备大量系统控制能力
+
+**证据**
+- systemd 服务中未降权（`User=root` 或默认 root），且程序内可执行 `systemctl`、`vtysh`、写系统配置。见 `scripts/install.sh` 生成的 service 与 `systemd/proxygw.service`。
+
+**风险**
+- 一旦后台被入侵，攻击者几乎直接获得主机完全控制权。
+
+**建议**
+1. 拆分权限：将 Web/API 进程降权运行，仅通过受控 helper 执行必要特权动作。
+2. 使用 systemd sandbox 选项（`NoNewPrivileges=yes`、`ProtectSystem=strict`、`ProtectHome=yes`、`PrivateTmp=yes` 等）。
+3. 以最小 capability 代替全量 root（如确有必要可评估 `AmbientCapabilities`）。
+
+---
+
+### 3) [中] 登录接口缺少限流/锁定策略，存在暴力破解面
+
+**证据**
+- `/api/login` 仅校验密码并返回 token，未见速率限制、失败计数或临时封禁。见 `backend/auth_routes.go`。
+
+**风险**
+- 面向公网暴露时，弱口令或泄露口令更易被撞库/爆破。
+
+**建议**
+1. 按 IP + 用户维度限流（如令牌桶）。
+2. 连续失败阈值后指数退避或短时封禁。
+3. 增加登录审计日志与告警。
+
+---
+
+### 4) [中] 会话 token 为全局常驻内存值，缺少过期与轮换机制
+
+**证据**
+- `sessionToken` 在进程启动时生成，后续所有登录成功均返回同一 token，且看不到 TTL/失效机制。见 `backend/main.go`、`backend/api_routes.go`、`backend/auth_routes.go`。
+
+**风险**
+- token 一旦泄露，在服务重启前可长期复用。
+
+**建议**
+1. 改为每次登录签发独立 token（JWT 或随机 session）。
+2. 增加过期时间、吊销机制、密码修改后强制失效旧会话。
+3. 支持手动“全部登出”。
+
+---
+
+### 5) [中] 外部 HTTP 客户端未设置超时，存在资源占用风险
+
+**证据**
+- `http.Get("https://api.github.com/repos/XTLS/Xray-core/releases")` 直接使用默认客户端。见 `backend/update_routes.go`。
+
+**风险**
+- 远端响应慢或网络异常时，可能造成请求堆积、连接长期占用。
+
+**建议**
+- 使用带超时的 `http.Client{Timeout: ...}`，并考虑 context 超时/取消。
+
+---
+
+### 6) [中] 默认明文 HTTP 监听（无 TLS 终止）
+
+**证据**
+- 后端直接 `r.Run(":80")`，README 示例访问地址为 `http://`。见 `backend/main.go`、`README.md`。
+
+**风险**
+- 管理口令与 token 在未加密链路上传输，易被窃听或中间人攻击（尤其跨网段管理场景）。
+
+**建议**
+1. 默认仅监听内网管理网卡。
+2. 建议前置 Nginx/Caddy/Traefik 强制 HTTPS。
+3. 文档中给出 TLS 最小部署模板。
+
+---
+
+### 7) [低] README 中“默认密码：admin”与当前实现不一致，存在误导
+
+**证据**
+- README 声明默认密码为 `admin`；但代码逻辑为首次启动随机密码或环境变量引导。见 `README.md`、`backend/main.go`。
+
+**风险**
+- 运维人员按错误认知部署，可能导致初始化/应急流程混乱。
+
+**建议**
+- 更新文档为“首次启动自动生成随机密码（或读取 `PROXYGW_BOOTSTRAP_PASSWORD`）”。
+
+---
+
+### 8) [低] 局部错误处理缺失，影响可观测性与稳定性
+
+**证据**
+- 存在多处 `Exec`/`Scan`/`WriteFile` 忽略返回值的情况。典型位置见 `backend/main.go`。
+
+**风险**
+- 故障时难以定位根因，某些安全控制可能“静默失败”。
+
+**建议**
+- 对关键路径统一补充错误日志，并将失败状态反馈到 API。
+
+---
+
+## 已验证的正向项
+
+1. 密码已采用 `bcrypt` 哈希存储，并支持历史明文密码向哈希迁移。  
+2. SQL 主要使用参数化语句，未发现直接字符串拼接注入点。  
+3. Xray 版本号输入存在正则约束，降低命令拼接风险。  
+4. WebSocket `Origin` 做了同主机校验，减少跨站滥用面。
+
+---
+
+## 优先级修复计划（建议）
+
+### P0（本周）
+- 为更新链路加入签名/哈希校验。
+- 引入登录限流与失败惩罚。
+
+### P1（两周内）
+- 完成 token 体系改造（TTL、轮换、吊销）。
+- 为外部 HTTP 请求加统一超时。
+- 更新 README 安全说明。
+
+### P2（一个月内）
+- 服务降权 + systemd 沙箱化。
+- 建立安全基线检查（lint + gosec + 配置扫描）并纳入 CI。
+
+---
+
+## 本次审计执行记录
+
+- 代码审阅：`backend/main.go`、`backend/auth_routes.go`、`backend/update_routes.go`、`backend/api_routes.go`、`backend/helpers.go`、`scripts/install.sh`、`systemd/proxygw.service`、`README.md`
+- 自动化检查：`cd backend && go test ./...`（通过）


### PR DESCRIPTION
### Motivation

- Capture a focused security audit of the backend, deployment scripts and docs to surface high/medium/low risks and recommendations. 
- Provide a prioritized remediation plan to guide immediate hardening work without modifying runtime behavior.

### Description

- Add `docs/AUDIT-2026-04-15.md` containing scope, methodology, 8 findings (2 high / 4 medium / 2 low), evidence locations and remediation recommendations. 
- Key findings highlighted include missing integrity checks for updates, the service running with root privileges, lack of login rate-limiting, single long-lived session token, missing HTTP client timeouts, plain HTTP admin listener, documentation mismatch about default password, and spotty error handling. 
- The report confirms positive controls (bcrypt for passwords, parameterized SQL, version regex, same-host WebSocket origin check) and provides a P0/P1/P2 prioritized fix plan. 
- This change is documentation-only and does not alter runtime code paths.

### Testing

- Ran the repository unit/integration tests with `cd backend && go test ./...` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5f9e21908325a120faba18495d1a)