### PR TITLE
Fix login UX: validate empty password and trim input

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -710,14 +710,18 @@ const showRollbackModal = ref(false);
 
                 const token = ref(localStorage.getItem('token') || '');
                 const password = ref('');
-                const login = async () => { console.log("login called");
+                const login = async () => {
                     if (isSubmitting.value.login) return;
-                    isSubmitting.value.login = true; alert("Login triggered!");
+                    if (!password.value || !password.value.trim()) {
+                        showToast("请输入密码", "error");
+                        return;
+                    }
+                    isSubmitting.value.login = true;
                     try {
                         const res = await fetch('/api/login', { 
                             method: 'POST', 
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ password: password.value }) 
+                            body: JSON.stringify({ password: password.value.trim() }) 
                         });
                         if(res.ok) {
                             const data = await res.json();


### PR DESCRIPTION
### Motivation
- Users reported clicking 登录 with no visible effect; the login handler contained leftover debug calls and lacked client-side validation for empty or whitespace-only passwords, causing poor feedback and unnecessary requests.

### Description
- Remove leftover debug `console.log` / `alert` calls from the login handler and add a client-side check to show a toast when the password is empty.
- Trim the password with `password.value.trim()` before sending the `/api/login` request to avoid failures caused by surrounding whitespace.
- Change applied in `frontend/dist/index.html` (adjusted login flow and submission body).

### Testing
- Ran `go test ./...` in the repository root which failed due to not being a Go module (expected environment issue).
- Ran `go test ./...` in `backend/` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c2359394832592c94405f6e3fb97)