### PR TITLE
Follow-up: enforce DNS log WS cap with atomic CAS admission

### DIFF
--- a/backend/dns_routes.go
+++ b/backend/dns_routes.go
@@ -15,6 +15,24 @@ import (
 
 var dnsLogWSConnections int32
 
+const maxDNSLogWSConnections int32 = 16
+
+func tryAcquireDNSLogWSConnection() bool {
+	for {
+		current := atomic.LoadInt32(&dnsLogWSConnections)
+		if current >= maxDNSLogWSConnections {
+			return false
+		}
+		if atomic.CompareAndSwapInt32(&dnsLogWSConnections, current, current+1) {
+			return true
+		}
+	}
+}
+
+func releaseDNSLogWSConnection() {
+	atomic.AddInt32(&dnsLogWSConnections, -1)
+}
+
 func registerDNSRoutes(api *gin.RouterGroup) {
 	api.GET("/dns", func(c *gin.Context) {
 		var local, remote, lazy, mode string
@@ -75,13 +93,11 @@ func registerDNSRoutes(api *gin.RouterGroup) {
 	})
 
 	api.GET("/dns/logs/ws", func(c *gin.Context) {
-		const maxDNSLogWSConnections = 16
-		if active := atomic.AddInt32(&dnsLogWSConnections, 1); active > maxDNSLogWSConnections {
-			atomic.AddInt32(&dnsLogWSConnections, -1)
+		if !tryAcquireDNSLogWSConnection() {
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many log streams"})
 			return
 		}
-		defer atomic.AddInt32(&dnsLogWSConnections, -1)
+		defer releaseDNSLogWSConnection()
 		ws, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 		if err != nil {
 			return


### PR DESCRIPTION
### Motivation
- Fix a race in the `/dns/logs/ws` admission logic that allowed concurrent handshakes to bypass the intended connection cap. 
- Ensure counting and admission for DNS log WebSocket streams are performed atomically to prevent FD/process spikes under load.

### Description
- Add `const maxDNSLogWSConnections int32 = 16` to centralize the configured cap. 
- Implement `tryAcquireDNSLogWSConnection()` which uses an atomic CAS loop to reserve a slot in a single atomic step. 
- Add `releaseDNSLogWSConnection()` and update the `/dns/logs/ws` handler to use the new acquire/release helpers with a deferred release to guarantee proper decrement on all exit paths.

### Testing
- Running `go test ./...` from the repository root failed because the Go module is located under `backend/` and the root is not a module. 
- Running `go test ./...` from `/workspace/proxygw/backend` completed successfully and returned `ok` for the backend package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0c33a20d483259967be6c452cf2e4)