### PR TITLE
refactor: remove dead unused subnet helper

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -814,29 +814,6 @@ func applyXrayConfig() error {
 	return exec.Command("systemctl", "restart", "xray").Run()
 }
 
-func getPrimarySubnet(ipStr string) string {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return ""
-	}
-	for _, i := range ifaces {
-		addrs, err := i.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, a := range addrs {
-			if ipnet, ok := a.(*net.IPNet); ok {
-				if ipnet.IP.String() == ipStr {
-					network := ipnet.IP.Mask(ipnet.Mask)
-					maskSize, _ := ipnet.Mask.Size()
-					return fmt.Sprintf("%s/%d", network.String(), maskSize)
-				}
-			}
-		}
-	}
-	return ""
-}
-
 func getPrimaryLANIPAndSubnet() (string, string) {
 	ifaces, err := net.Interfaces()
 	if err != nil {


### PR DESCRIPTION
### Motivation
- Remove a definitively-unused helper to reduce dead code and maintenance surface in `backend/main.go`.

### Description
- Deleted the unused `getPrimarySubnet(ipStr string) string` function from `backend/main.go` and kept `getPrimaryLANIPAndSubnet` and FRR sync logic unchanged.

### Testing
- Ran `cd backend && go test ./... -run TestNonExistent` and `cd backend && go vet ./...`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7477ec07c83259a81c76af31726fb)