### PR TITLE
fix(remote-node): stop auto-trusting rotated SSH host keys

### DIFF
--- a/backend/remote_node_mock_test.go
+++ b/backend/remote_node_mock_test.go
@@ -267,3 +267,79 @@ func TestWrapRemoteCommandWithSudo_RootNoWrap(t *testing.T) {
 		t.Fatalf("expected raw command, got: %s", got)
 	}
 }
+
+func TestPinInitialHostKeyIsConditional(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	repo := NewRemoteNodesRepository()
+
+	// Node 2 is seeded with a pinned key; the conditional pin must not overwrite it.
+	pinned, err := repo.PinInitialHostKey(2, "SHA256:SHOULD-NOT-APPLY")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pinned {
+		t.Fatal("pin must be rejected when a key is already pinned")
+	}
+	var k string
+	if err := db.QueryRow("SELECT ssh_host_key FROM remote_nodes WHERE id=2").Scan(&k); err != nil {
+		t.Fatal(err)
+	}
+	if k != "SHA256:test" {
+		t.Fatalf("stored key was overwritten: %s", k)
+	}
+
+	// Clear the key; the conditional pin should now succeed and store the value.
+	if _, err := db.Exec("UPDATE remote_nodes SET ssh_host_key='' WHERE id=2"); err != nil {
+		t.Fatal(err)
+	}
+	pinned, err = repo.PinInitialHostKey(2, "SHA256:newfp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pinned {
+		t.Fatal("pin should succeed when no key is pinned")
+	}
+	if err := db.QueryRow("SELECT ssh_host_key FROM remote_nodes WHERE id=2").Scan(&k); err != nil {
+		t.Fatal(err)
+	}
+	if k != "SHA256:newfp" {
+		t.Fatalf("pin not stored, got %s", k)
+	}
+}
+
+func postJSON(target, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestUpdateRemoteNodeHostKeyEndpoint(t *testing.T) {
+	r := setupFeatureSuiteRouter(t)
+	validFP := "SHA256:ADjw2yeU9EmUjcrBrwreHH7cJLe3lNRiPHFhTu3PPio"
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, postJSON("/api/remote_nodes/2/hostkey", `{"ssh_host_key":"garbage"}`))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid fingerprint: want 400 got %d body=%s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, postJSON("/api/remote_nodes/2/hostkey", `{"ssh_host_key":"`+validFP+`"}`))
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid update: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var k string
+	if err := db.QueryRow("SELECT ssh_host_key FROM remote_nodes WHERE id=2").Scan(&k); err != nil {
+		t.Fatal(err)
+	}
+	if k != validFP {
+		t.Fatalf("host key not updated, got %s", k)
+	}
+
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, postJSON("/api/remote_nodes/999/hostkey", `{"ssh_host_key":"`+validFP+`"}`))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("missing node: want 404 got %d", w.Code)
+	}
+}

--- a/backend/remote_node_mock_test.go
+++ b/backend/remote_node_mock_test.go
@@ -197,7 +197,7 @@ func TestDoDeployRoutine_LogsRemoteStdoutAndStderrOnFailure(t *testing.T) {
 	}
 }
 
-func TestDoDeployRoutine_AutoUpdatesFingerprintAndRetries(t *testing.T) {
+func TestDoDeployRoutine_RefusesToAutoTrustRotatedFingerprint(t *testing.T) {
 	setupFeatureSuiteRouter(t)
 
 	oldConnect := remoteConnect
@@ -207,18 +207,10 @@ func TestDoDeployRoutine_AutoUpdatesFingerprintAndRetries(t *testing.T) {
 	calls := 0
 	remoteConnect = func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
 		calls++
-		if calls == 1 {
-			if expectedHostKey != "SHA256:old" {
-				t.Fatalf("first connect expected old key, got %s", expectedHostKey)
-			}
-			return nil, fmt.Errorf("failed to dial: ssh: handshake failed: Strict Host Key checking failed. The server's fingerprint is %s. Please update", newFP)
+		if expectedHostKey != "SHA256:test" {
+			t.Fatalf("expected pinned key, got %s", expectedHostKey)
 		}
-		if expectedHostKey != newFP {
-			t.Fatalf("second connect expected new key, got %s", expectedHostKey)
-		}
-		return &fakeSSHClient{run: func(cmd string) (string, string, error) {
-			return "", "", nil
-		}}, nil
+		return nil, fmt.Errorf("failed to dial: ssh: handshake failed: Strict Host Key checking failed. The server's fingerprint is %s. Please update", newFP)
 	}
 
 	req := RemoteNodeReq{
@@ -227,7 +219,7 @@ func TestDoDeployRoutine_AutoUpdatesFingerprintAndRetries(t *testing.T) {
 		SSHHost:       "192.168.20.152",
 		SSHPort:       22,
 		SSHUser:       "root",
-		SSHHostKey:    "SHA256:old",
+		SSHHostKey:    "SHA256:test",
 		SSHAuthType:   "password",
 		SSHCredential: "secret123",
 		Region:        "lab",
@@ -236,27 +228,27 @@ func TestDoDeployRoutine_AutoUpdatesFingerprintAndRetries(t *testing.T) {
 
 	doDeployRoutine(2, req, true, nil)
 
-	if calls != 2 {
-		t.Fatalf("expected 2 connect attempts, got %d", calls)
+	if calls != 1 {
+		t.Fatalf("expected a single connect attempt (no auto-trust retry), got %d", calls)
 	}
 
 	var status, hostKey string
 	if err := db.QueryRow("SELECT status, ssh_host_key FROM remote_nodes WHERE id = 2").Scan(&status, &hostKey); err != nil {
 		t.Fatal(err)
 	}
-	if status != "Online" {
-		t.Fatalf("want status Online got %s", status)
+	if status != "Failed" {
+		t.Fatalf("want status Failed got %s", status)
 	}
-	if hostKey != newFP {
-		t.Fatalf("want updated hostkey %s got %s", newFP, hostKey)
+	if hostKey != "SHA256:test" {
+		t.Fatalf("stored host key must not be silently rotated, got %s", hostKey)
 	}
 
-	var hasAutoUpdateLog int
-	if err := db.QueryRow("SELECT COUNT(*) FROM remote_node_logs WHERE node_id=2 AND log_text LIKE '%Auto-updated SSH host fingerprint%'").Scan(&hasAutoUpdateLog); err != nil {
+	var refusalLog int
+	if err := db.QueryRow("SELECT COUNT(*) FROM remote_node_logs WHERE node_id=2 AND log_text LIKE '%refusing to auto-trust rotated SSH host key%'").Scan(&refusalLog); err != nil {
 		t.Fatal(err)
 	}
-	if hasAutoUpdateLog == 0 {
-		t.Fatal("expected auto-update fingerprint log entry")
+	if refusalLog == 0 {
+		t.Fatal("expected refusal log entry")
 	}
 }
 

--- a/backend/remote_nodes_controller.go
+++ b/backend/remote_nodes_controller.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"log"
 	"net/http"
 	"net/url"
 	"proxygw/remote_deploy"
@@ -80,6 +81,7 @@ func (ctl *RemoteNodesController) RegisterRoutes(authed *gin.RouterGroup) {
 	authed.POST("/remote_nodes", createAndDeployRemoteNode)
 	authed.DELETE("/remote_nodes/:id", deleteRemoteNode)
 	authed.POST("/remote_nodes/:id/check", checkRemoteNode)
+	authed.POST("/remote_nodes/:id/hostkey", updateRemoteNodeHostKey)
 
 	// Advanced Features
 	authed.POST("/remote_nodes/batch", batchDeployRemoteNodes)
@@ -152,6 +154,43 @@ func logAction(nodeId int64, action, status, logText string) {
 
 var hostKeyFingerprintRe = regexp.MustCompile(`SHA256:[A-Za-z0-9+/=_-]+`)
 
+// sshHostKeyFingerprintRe validates an explicit, user-supplied SSH host key
+// fingerprint (as logged by ssh / ssh-keygen, e.g. "SHA256:abc...xyz=").
+var sshHostKeyFingerprintRe = regexp.MustCompile(`^SHA256:[A-Za-z0-9+/=_-]{43,44}$`)
+
+func isValidSSHHostKeyFingerprint(s string) bool {
+	return sshHostKeyFingerprintRe.MatchString(strings.TrimSpace(s))
+}
+
+// updateRemoteNodeHostKey provides an explicit, user-confirmed recovery path
+// for a legitimately rotated host key: instead of silently auto-trusting, the
+// operator verifies the new fingerprint out-of-band and submits it here.
+func updateRemoteNodeHostKey(c *gin.Context) {
+	id := c.Param("id")
+	var req struct {
+		SSHHostKey string `json:"ssh_host_key"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
+		return
+	}
+	fp := strings.TrimSpace(req.SSHHostKey)
+	if !isValidSSHHostKeyFingerprint(fp) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid SSH host key fingerprint (expected SHA256:<base64>)"})
+		return
+	}
+	if _, err := NewRemoteNodesRepository().FetchNodeReq(id); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Node not found"})
+		return
+	}
+	if err := NewRemoteNodesRepository().SetRemoteNodeHostKey(id, fp); err != nil {
+		log.Printf("[ERR] SetRemoteNodeHostKey: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update host key"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "ssh_host_key": fp})
+}
+
 func extractFingerprintFromSSHError(err error) string {
 	if err == nil {
 		return ""
@@ -180,8 +219,16 @@ func connectWithAutoHostKey(id int64, req *RemoteNodeReq) (remoteSSHClient, erro
 		return nil, fmt.Errorf("refusing to auto-trust rotated SSH host key for node %d (stored %s, presented %s): update the pinned host key explicitly to proceed", id, req.SSHHostKey, fp)
 	}
 
-	if uerr := NewRemoteNodesRepository().UpdateRemoteNodeHostKey(id, fp); uerr != nil {
+	// The first routine to reach this point with an empty stored key pins the
+	// fingerprint. The update is conditional on the row still having an empty
+	// key so a concurrent deploy cannot overwrite an already-pinned key with a
+	// different fingerprint (which would reintroduce silent rotation).
+	pinned, uerr := NewRemoteNodesRepository().PinInitialHostKey(id, fp)
+	if uerr != nil {
 		return nil, fmt.Errorf("%v; auto-update host key failed: %v", err, uerr)
+	}
+	if !pinned {
+		return nil, fmt.Errorf("host key for node %d was pinned concurrently by another operation (stored key changed while deploying); refusing to overwrite, retry the deployment", id)
 	}
 	logAction(id, "deploy", "running", fmt.Sprintf("Pinned initial SSH host fingerprint to %s and retrying deployment", fp))
 	req.SSHHostKey = fp

--- a/backend/remote_nodes_controller.go
+++ b/backend/remote_nodes_controller.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"proxygw/remote_deploy"
 	"regexp"
+	"runtime/debug"
 	"strings"
 )
 
@@ -128,8 +129,15 @@ func getRemoteNodeDetails(c *gin.Context) {
 	} else if basic.Type == "vless" {
 		v, err := repo.GetRemoteNodeVLESSParams(id)
 		if err == nil {
+			// The provisioning share link intentionally embeds the VLESS UUID (and
+			// the WireGuard client private key in the WG branch above) so the link can
+			// be imported directly into a client device. Because the secret is
+			// deliberately carried by the share link, do not also return a standalone
+			// secret field that merely mimics redaction while the value is already
+			// present in the link. Only the exportable share link and public metadata
+			// are surfaced, consistent with the WireGuard branch.
 			node["vless"] = map[string]interface{}{
-				"uuid": "***REDACTED***", "reality_pub": v.RealityPub, "short_id": v.ShortID,
+				"reality_pub": v.RealityPub, "short_id": v.ShortID,
 				"server_name": v.ServerName, "dest": v.Dest, "port": v.Port, "share_link": v.ShareLink,
 			}
 		}
@@ -162,10 +170,20 @@ func connectWithAutoHostKey(id int64, req *RemoteNodeReq) (remoteSSHClient, erro
 		return nil, err
 	}
 
+	// Trust-on-first-use (TOFU) is only acceptable while provisioning a node that
+	// has no pinned host key yet. If a host key is already stored and the server
+	// now presents a different one, silently trusting it would let a MITM
+	// substitute its own key and have it accepted. Treat a rotation of an
+	// already-pinned key as a hard failure and require an explicit update
+	// (e.g. re-create the node) instead of auto-trusting.
+	if strings.TrimSpace(req.SSHHostKey) != "" {
+		return nil, fmt.Errorf("refusing to auto-trust rotated SSH host key for node %d (stored %s, presented %s): update the pinned host key explicitly to proceed", id, req.SSHHostKey, fp)
+	}
+
 	if uerr := NewRemoteNodesRepository().UpdateRemoteNodeHostKey(id, fp); uerr != nil {
 		return nil, fmt.Errorf("%v; auto-update host key failed: %v", err, uerr)
 	}
-	logAction(id, "deploy", "running", fmt.Sprintf("Auto-updated SSH host fingerprint to %s and retrying deployment", fp))
+	logAction(id, "deploy", "running", fmt.Sprintf("Pinned initial SSH host fingerprint to %s and retrying deployment", fp))
 	req.SSHHostKey = fp
 
 	sshClient, err = remoteConnect(req.SSHHost, req.SSHPort, req.SSHUser, req.SSHAuthType, req.SSHCredential, req.SSHHostKey)
@@ -180,6 +198,14 @@ var deploySemaphore = make(chan struct{}, 3)
 func doDeployRoutineWrapper(id int64, req RemoteNodeReq, isUpdate bool, params map[string]interface{}) {
 	deploySemaphore <- struct{}{}
 	defer func() { <-deploySemaphore }()
+	defer func() {
+		// A panic inside a background deploy must not take down the whole gateway
+		// backend; mark the node failed and surface the stack for diagnosis.
+		if r := recover(); r != nil {
+			NewRemoteNodesRepository().SetRemoteNodeStatus(id, "Failed")
+			logAction(id, "deploy", "failed", fmt.Sprintf("deployment panicked: %v\n%s", r, debug.Stack()))
+		}
+	}()
 	doDeployRoutine(id, req, isUpdate, params)
 }
 

--- a/backend/remote_nodes_repository.go
+++ b/backend/remote_nodes_repository.go
@@ -114,6 +114,26 @@ func (r *RemoteNodesRepository) UpdateRemoteNodeHostKey(id int64, hostKey string
 	return err
 }
 
+// PinInitialHostKey stores hostKey only if the node does not yet have a pinned
+// host key, and reports whether it pinned it. This makes the trust-on-first-use
+// pin race-safe: among concurrent deploys only the first one wins.
+func (r *RemoteNodesRepository) PinInitialHostKey(id int64, hostKey string) (bool, error) {
+	res, err := r.db.Exec("UPDATE remote_nodes SET ssh_host_key = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND (ssh_host_key IS NULL OR ssh_host_key = '')", hostKey, id)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
+}
+
+// SetRemoteNodeHostKey is an explicit, user-confirmed update of a verified host
+// key (recovery path for legitimate rotations); unlike PinInitialHostKey it is
+// unconditional.
+func (r *RemoteNodesRepository) SetRemoteNodeHostKey(id, hostKey string) error {
+	_, err := r.db.Exec("UPDATE remote_nodes SET ssh_host_key = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?", hostKey, id)
+	return err
+}
+
 func (r *RemoteNodesRepository) GetRemoteNodeCheckInfo(id string) (RemoteNodeCheckInfo, error) {
 	var info RemoteNodeCheckInfo
 	err := r.db.QueryRow("SELECT ssh_host, ssh_port, ssh_user, ssh_auth_type, ssh_credential, ssh_host_key, type FROM remote_nodes WHERE id = ?", id).


### PR DESCRIPTION
The SSH host-key auto-trust logic silently replaced a pinned host key and retried the connection whenever the server presented a different key. This defeats Strict Host Key checking and lets a MITM substitute its own key and have it accepted.

- Only trust-on-first-use (TOFU) when no key is pinned yet (initial provisioning). A rotation of an already-pinned key is now a hard failure requiring an explicit update, not a silent re-trust.
- Remove the misleading VLESS "uuid" redaction placeholder: the value is deliberately carried by the exportable provisioning share link (same as the WireGuard branch), so a decoy redacted field only created false security.
- Recover from panics in the background remote-deploy goroutine instead of crashing the whole gateway backend; mark the node Failed with the stack.

Test: replace the old auto-trust retry test with one asserting the refusal, no retry and no silent key rotation. Full backend suite passes.