### PR TITLE
fix(security): rotate legacy hardcoded AES key and re-encrypt credent…

### DIFF
--- a/backend/app_runtime_shared.go
+++ b/backend/app_runtime_shared.go
@@ -199,11 +199,19 @@ func setDomainGeoIPMatchCache(key string, tags []string) {
 }
 
 var runVtyshConfigBatch = func(config string) (string, error) {
-	tmpFile := "/tmp/proxygw_vtysh_batch.conf"
-	if err := os.WriteFile(tmpFile, []byte(config), 0600); err != nil {
+	f, err := os.CreateTemp("", "proxygw_vtysh_batch-*.conf")
+	if err != nil {
 		return "", err
 	}
+	tmpFile := f.Name()
 	defer os.Remove(tmpFile)
+	if _, err := f.WriteString(config); err != nil {
+		f.Close()
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
 	res := sysCmd.runCombinedOutput("vtysh", "-f", tmpFile)
 	return string(res.Output), res.Err
 }

--- a/backend/crypto_utils.go
+++ b/backend/crypto_utils.go
@@ -1,39 +1,134 @@
 package main
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
 	"io"
+	"log"
 	"os"
+	"strings"
 )
 
 var aesKey []byte
 
+// legacyAESKey is the hardcoded key that was historically used to encrypt SSH
+// credentials before per-install random keys were introduced. It must NEVER be
+// persisted or used as the long-term key; it is only used once to migrate
+// existing rows to a freshly generated key and then discarded. Keeping it as a
+// constant also lets us detect installs that still hold it in aes.key.
+var legacyAESKey = []byte("proxygw-secret-key-32-bytes-long")
+
+// migrateLegacyCredentials indicates some remote_nodes rows may still be
+// encrypted with legacyAESKey and must be re-encrypted with the current aesKey.
+var migrateLegacyCredentials bool
+
 func init() {
 	keyPath := getPath("config", "aes.key")
-	data, err := os.ReadFile(keyPath)
-	if err == nil && len(data) == 32 {
-		aesKey = data
+	stored, readErr := os.ReadFile(keyPath)
+	if readErr == nil && len(stored) == 32 && !bytes.Equal(stored, legacyAESKey) {
+		aesKey = stored
 		return
 	}
 
-	oldKey := []byte("proxygw-secret-key-32-bytes-long")
-	dbPath := getPath("config", "proxygw.db")
-	if _, err := os.Stat(dbPath); err == nil {
-		aesKey = oldKey
-	} else {
-		aesKey = make([]byte, 32)
-		if _, err := io.ReadFull(rand.Reader, aesKey); err != nil {
-			aesKey = oldKey
-		}
+	// No key file, or it still contains the well-known legacy constant: always
+	// rotate to a fresh random key. A hardcoded public value must never become
+	// the persisted encryption key, otherwise every install would share the same
+	// key and SSH credentials would be trivially decryptable from source.
+	aesKey = make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, aesKey); err != nil {
+		log.Printf("[CRITICAL] failed to generate AES key: %v", err)
+		aesKey = append([]byte(nil), legacyAESKey...)
 	}
-	os.WriteFile(keyPath, aesKey, 0600)
+
+	// Only schedule a migration when an existing database may hold rows that were
+	// encrypted with the legacy key: either the key file was missing while a DB
+	// is present, or the key file itself still contained the legacy constant.
+	var dbPresent bool
+	if _, err := os.Stat(getPath("config", "proxygw.db")); err == nil {
+		dbPresent = true
+	}
+	migrateLegacyCredentials = dbPresent || (readErr == nil && bytes.Equal(stored, legacyAESKey))
+
+	if err := os.WriteFile(keyPath, aesKey, 0600); err != nil {
+		log.Printf("[SECURITY] failed to persist AES key: %v", err)
+	}
 }
 
-func EncryptAES(text string) string {
-	block, err := aes.NewCipher(aesKey)
+// migrateLegacyCredentialsIfNeeded re-encrypts any SSH credentials that were
+// stored with the legacy hardcoded key using the current random aesKey. It is
+// a no-op unless init() detected a legacy-encrypted database.
+func migrateLegacyCredentialsIfNeeded() {
+	if !migrateLegacyCredentials {
+		return
+	}
+	migrateLegacyCredentials = false
+
+	rows, err := db.Query("SELECT id, ssh_credential FROM remote_nodes")
+	if err != nil {
+		log.Printf("[SECURITY] migrate legacy credentials: query failed: %v", err)
+		return
+	}
+	type update struct {
+		id  int64
+		enc string
+	}
+	var updates []update
+	for rows.Next() {
+		var id int64
+		var cred string
+		if err := rows.Scan(&id, &cred); err != nil {
+			continue
+		}
+		if !strings.HasPrefix(cred, "ENC:") {
+			continue
+		}
+		plain := decryptAESWithKey(cred, legacyAESKey)
+		if plain == cred {
+			// Cannot be decoded with the legacy key; leave the row untouched.
+			continue
+		}
+		if enc := encryptAESWithKey(plain, aesKey); enc != cred {
+			updates = append(updates, update{id: id, enc: enc})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("[SECURITY] migrate legacy credentials: rows error: %v", err)
+		rows.Close()
+		return
+	}
+	rows.Close()
+	if len(updates) == 0 {
+		return
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		log.Printf("[SECURITY] migrate legacy credentials: begin tx failed: %v", err)
+		return
+	}
+	for _, u := range updates {
+		if _, err := tx.Exec("UPDATE remote_nodes SET ssh_credential=? WHERE id=?", u.enc, u.id); err != nil {
+			_ = tx.Rollback()
+			log.Printf("[SECURITY] migrate legacy credentials: update failed: %v", err)
+			return
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		log.Printf("[SECURITY] migrate legacy credentials: commit failed: %v", err)
+		return
+	}
+	log.Printf("[SECURITY] rotated %d legacy SSH credentials to a fresh AES key", len(updates))
+}
+
+func EncryptAES(text string) string { return encryptAESWithKey(text, aesKey) }
+
+func DecryptAES(text string) string { return decryptAESWithKey(text, aesKey) }
+
+func encryptAESWithKey(text string, key []byte) string {
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return text
 	}
@@ -48,7 +143,7 @@ func EncryptAES(text string) string {
 	return "ENC:" + base64.StdEncoding.EncodeToString(ciphertext)
 }
 
-func DecryptAES(text string) string {
+func decryptAESWithKey(text string, key []byte) string {
 	if len(text) < 4 || text[:4] != "ENC:" {
 		return text
 	}
@@ -57,7 +152,7 @@ func DecryptAES(text string) string {
 	if err != nil || len(ciphertext) < aes.BlockSize {
 		return text
 	}
-	block, err := aes.NewCipher(aesKey)
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return text
 	}

--- a/backend/crypto_utils.go
+++ b/backend/crypto_utils.go
@@ -16,50 +16,60 @@ var aesKey []byte
 
 // legacyAESKey is the hardcoded key that was historically used to encrypt SSH
 // credentials before per-install random keys were introduced. It must NEVER be
-// persisted or used as the long-term key; it is only used once to migrate
-// existing rows to a freshly generated key and then discarded. Keeping it as a
-// constant also lets us detect installs that still hold it in aes.key.
+// persisted or used as the long-term key; it is only used to migrate existing
+// rows to a freshly generated key and then discarded. Keeping it as a constant
+// also lets us detect installs that still hold it in aes.key.
 var legacyAESKey = []byte("proxygw-secret-key-32-bytes-long")
 
 // migrateLegacyCredentials indicates some remote_nodes rows may still be
 // encrypted with legacyAESKey and must be re-encrypted with the current aesKey.
 var migrateLegacyCredentials bool
 
+// rotationPendingPath marks that a key rotation started but legacy credentials
+// may not have been re-encrypted yet. Its presence makes migration retry on the
+// next boot even if the process crashed after the key file was written but
+// before legacy rows were re-encrypted.
+func rotationPendingPath() string { return getPath("config", "aes.rotation_pending") }
+
 func init() {
 	keyPath := getPath("config", "aes.key")
 	stored, readErr := os.ReadFile(keyPath)
+	rotated := false
 	if readErr == nil && len(stored) == 32 && !bytes.Equal(stored, legacyAESKey) {
 		aesKey = stored
-		return
+	} else {
+		// Missing key file, or it still contains the well-known legacy constant:
+		// always rotate to a fresh random key. A hardcoded public value must
+		// never become the persisted encryption key, otherwise every install
+		// would share the same key and SSH credentials would be trivially
+		// decryptable from source.
+		aesKey = make([]byte, 32)
+		if _, err := io.ReadFull(rand.Reader, aesKey); err != nil {
+			log.Printf("[CRITICAL] failed to generate AES key: %v", err)
+			aesKey = append([]byte(nil), legacyAESKey...)
+		}
+		if err := os.WriteFile(keyPath, aesKey, 0600); err != nil {
+			log.Printf("[SECURITY] failed to persist AES key: %v", err)
+		}
+		rotated = true
 	}
 
-	// No key file, or it still contains the well-known legacy constant: always
-	// rotate to a fresh random key. A hardcoded public value must never become
-	// the persisted encryption key, otherwise every install would share the same
-	// key and SSH credentials would be trivially decryptable from source.
-	aesKey = make([]byte, 32)
-	if _, err := io.ReadFull(rand.Reader, aesKey); err != nil {
-		log.Printf("[CRITICAL] failed to generate AES key: %v", err)
-		aesKey = append([]byte(nil), legacyAESKey...)
-	}
-
-	// Only schedule a migration when an existing database may hold rows that were
-	// encrypted with the legacy key: either the key file was missing while a DB
-	// is present, or the key file itself still contained the legacy constant.
-	var dbPresent bool
-	if _, err := os.Stat(getPath("config", "proxygw.db")); err == nil {
-		dbPresent = true
-	}
-	migrateLegacyCredentials = dbPresent || (readErr == nil && bytes.Equal(stored, legacyAESKey))
-
-	if err := os.WriteFile(keyPath, aesKey, 0600); err != nil {
-		log.Printf("[SECURITY] failed to persist AES key: %v", err)
+	// Schedule migration when we just rotated, or when a previous rotation was
+	// interrupted (pending marker present). The marker keeps migration retryable
+	// across crashes so credentials are never left undecryptable.
+	if rotated {
+		_ = os.WriteFile(rotationPendingPath(), []byte("1"), 0600)
+		migrateLegacyCredentials = true
+	} else if _, err := os.Stat(rotationPendingPath()); err == nil {
+		migrateLegacyCredentials = true
 	}
 }
 
-// migrateLegacyCredentialsIfNeeded re-encrypts any SSH credentials that were
-// stored with the legacy hardcoded key using the current random aesKey. It is
-// a no-op unless init() detected a legacy-encrypted database.
+// migrateLegacyCredentialsIfNeeded re-encrypts any SSH credentials still stored
+// with the legacy hardcoded key using the current random aesKey. It is a no-op
+// unless init() detected a legacy-encrypted database (or an interrupted rotation,
+// via the pending marker). Rows that cannot be decrypted with either the current
+// or the legacy key are left untouched rather than rewritten.
 func migrateLegacyCredentialsIfNeeded() {
 	if !migrateLegacyCredentials {
 		return
@@ -85,9 +95,14 @@ func migrateLegacyCredentialsIfNeeded() {
 		if !strings.HasPrefix(cred, "ENC:") {
 			continue
 		}
-		plain := decryptAESWithKey(cred, legacyAESKey)
-		if plain == cred {
-			// Cannot be decoded with the legacy key; leave the row untouched.
+		// Idempotency: rows already encrypted with the current key are skipped.
+		if _, ok := decryptAESCore(cred, aesKey); ok {
+			continue
+		}
+		plain, ok := decryptAESCore(cred, legacyAESKey)
+		if !ok {
+			// Not decryptable with the legacy key (e.g. foreign/malformed):
+			// preserve the value verbatim instead of corrupting it.
 			continue
 		}
 		if enc := encryptAESWithKey(plain, aesKey); enc != cred {
@@ -100,32 +115,42 @@ func migrateLegacyCredentialsIfNeeded() {
 		return
 	}
 	rows.Close()
-	if len(updates) == 0 {
-		return
-	}
 
-	tx, err := db.Begin()
-	if err != nil {
-		log.Printf("[SECURITY] migrate legacy credentials: begin tx failed: %v", err)
-		return
-	}
-	for _, u := range updates {
-		if _, err := tx.Exec("UPDATE remote_nodes SET ssh_credential=? WHERE id=?", u.enc, u.id); err != nil {
-			_ = tx.Rollback()
-			log.Printf("[SECURITY] migrate legacy credentials: update failed: %v", err)
+	if len(updates) > 0 {
+		tx, err := db.Begin()
+		if err != nil {
+			log.Printf("[SECURITY] migrate legacy credentials: begin tx failed: %v", err)
+			return
+		}
+		for _, u := range updates {
+			if _, err := tx.Exec("UPDATE remote_nodes SET ssh_credential=? WHERE id=?", u.enc, u.id); err != nil {
+				_ = tx.Rollback()
+				log.Printf("[SECURITY] migrate legacy credentials: update failed: %v", err)
+				return
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			log.Printf("[SECURITY] migrate legacy credentials: commit failed: %v", err)
 			return
 		}
 	}
-	if err := tx.Commit(); err != nil {
-		log.Printf("[SECURITY] migrate legacy credentials: commit failed: %v", err)
-		return
-	}
-	log.Printf("[SECURITY] rotated %d legacy SSH credentials to a fresh AES key", len(updates))
+
+	// Only clear the pending marker after the rotation fully committed, so an
+	// interrupted migration is retried on the next boot.
+	_ = os.Remove(rotationPendingPath())
+	log.Printf("[SECURITY] key rotation completed; migrated %d legacy credentials", len(updates))
 }
 
 func EncryptAES(text string) string { return encryptAESWithKey(text, aesKey) }
 
-func DecryptAES(text string) string { return decryptAESWithKey(text, aesKey) }
+func DecryptAES(text string) string {
+	plain, ok := decryptAESCore(text, aesKey)
+	if !ok {
+		// Preserve the input unchanged when it cannot be decrypted.
+		return text
+	}
+	return plain
+}
 
 func encryptAESWithKey(text string, key []byte) string {
 	block, err := aes.NewCipher(key)
@@ -143,26 +168,29 @@ func encryptAESWithKey(text string, key []byte) string {
 	return "ENC:" + base64.StdEncoding.EncodeToString(ciphertext)
 }
 
-func decryptAESWithKey(text string, key []byte) string {
+// decryptAESCore decrypts text and reports whether decryption succeeded. Unlike
+// a bare "return input on failure", callers can rely on the bool to distinguish
+// a valid plaintext from a non-decryptable value.
+func decryptAESCore(text string, key []byte) (string, bool) {
 	if len(text) < 4 || text[:4] != "ENC:" {
-		return text
+		return "", false
 	}
-	text = text[4:]
-	ciphertext, err := base64.StdEncoding.DecodeString(text)
+	payload := text[4:]
+	ciphertext, err := base64.StdEncoding.DecodeString(payload)
 	if err != nil || len(ciphertext) < aes.BlockSize {
-		return text
+		return "", false
 	}
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return text
+		return "", false
 	}
 	iv := ciphertext[:aes.BlockSize]
 	ciphertext = ciphertext[aes.BlockSize:]
 	cfb := cipher.NewCFBDecrypter(block, iv)
 	cfb.XORKeyStream(ciphertext, ciphertext)
-	data, err := base64.StdEncoding.DecodeString(string(ciphertext))
+	plain, err := base64.StdEncoding.DecodeString(string(ciphertext))
 	if err != nil {
-		return text
+		return "", false
 	}
-	return string(data)
+	return string(plain), true
 }

--- a/backend/crypto_utils_test.go
+++ b/backend/crypto_utils_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -14,32 +15,35 @@ func TestAESCryptoRoundTrip(t *testing.T) {
 	if enc == "topsecret" || len(enc) < 4 || enc[:4] != "ENC:" {
 		t.Fatalf("encrypt did not produce an ENC: payload: %q", enc)
 	}
-	if dec := decryptAESWithKey(enc, key); dec != "topsecret" {
-		t.Fatalf("round-trip failed: got %q", dec)
+	if got, ok := decryptAESCore(enc, key); !ok || got != "topsecret" {
+		t.Fatalf("round-trip failed: ok=%v got=%q", ok, got)
 	}
-	if d := decryptAESWithKey(enc, []byte("ffffffffffffffffffffffffffffffff")); d == "topsecret" {
+	if _, ok := decryptAESCore(enc, []byte("ffffffffffffffffffffffffffffffff")); ok {
 		t.Fatal("decrypt with wrong key leaked plaintext")
 	}
 }
 
-func TestMigrateLegacyCredentialsIfNeeded(t *testing.T) {
+func newTestDB(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
 	dir := t.TempDir()
 	tdb, err := sql.Open("sqlite3", filepath.Join(dir, "t.db"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tdb.Close()
 	if _, err := tdb.Exec(`CREATE TABLE remote_nodes (id INTEGER PRIMARY KEY AUTOINCREMENT, ssh_credential TEXT)`); err != nil {
 		t.Fatal(err)
 	}
-
 	oldDB := db
 	oldKey := aesKey
 	oldMigrate := migrateLegacyCredentials
 	db = tdb
-	newKey := []byte("abcdef0123456789abcdef0123456789")
-	aesKey = newKey
-	defer func() { db = oldDB; aesKey = oldKey; migrateLegacyCredentials = oldMigrate }()
+	aesKey = []byte("abcdef0123456789abcdef0123456789")
+	return tdb, func() { tdb.Close(); db = oldDB; aesKey = oldKey; migrateLegacyCredentials = oldMigrate }
+}
+
+func TestMigrateLegacyCredentialsIfNeeded(t *testing.T) {
+	_, restore := newTestDB(t)
+	defer restore()
 
 	if _, err := db.Exec(`INSERT INTO remote_nodes (ssh_credential) VALUES (?)`,
 		encryptAESWithKey("legacy-secret", legacyAESKey)); err != nil {
@@ -57,13 +61,13 @@ func TestMigrateLegacyCredentialsIfNeeded(t *testing.T) {
 	if err := db.QueryRow(`SELECT ssh_credential FROM remote_nodes WHERE id=1`).Scan(&enc); err != nil {
 		t.Fatal(err)
 	}
-	if got := decryptAESWithKey(enc, aesKey); got != "legacy-secret" {
-		t.Fatalf("migrated credential not decryptable with new key: got %q", got)
+	if got, ok := decryptAESCore(enc, aesKey); !ok || got != "legacy-secret" {
+		t.Fatalf("migrated credential not decryptable with new key: ok=%v got=%q", ok, got)
 	}
 	// The new key must differ from the legacy key, so the credential is no
 	// longer decryptable with the well-known constant.
-	if got := decryptAESWithKey(enc, legacyAESKey); got == "legacy-secret" {
-		t.Fatal("migrated credential is still decryptable with the legacy key")
+	if _, ok := decryptAESCore(enc, legacyAESKey); ok {
+		t.Fatalf("migrated credential is still decryptable with the legacy key: %q", enc)
 	}
 
 	var plain string
@@ -72,5 +76,59 @@ func TestMigrateLegacyCredentialsIfNeeded(t *testing.T) {
 	}
 	if plain != "plain-legacy" {
 		t.Fatalf("plaintext non-ENC legacy value should be untouched, got %q", plain)
+	}
+}
+
+// A row encrypted with a key that is neither the current nor the legacy key
+// must be preserved verbatim, not re-encrypted into garbage (P2).
+func TestMigrateLegacyLeavesForeignENCRowUntouched(t *testing.T) {
+	_, restore := newTestDB(t)
+	defer restore()
+
+	foreignKey := []byte("11111111111111111111111111111111")
+	foreign := encryptAESWithKey("secret-of-another-key", foreignKey)
+	if _, err := db.Exec(`INSERT INTO remote_nodes (ssh_credential) VALUES (?)`, foreign); err != nil {
+		t.Fatal(err)
+	}
+
+	migrateLegacyCredentials = true
+	migrateLegacyCredentialsIfNeeded()
+
+	var stored string
+	if err := db.QueryRow(`SELECT ssh_credential FROM remote_nodes WHERE id=1`).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != foreign {
+		t.Fatalf("foreign ENC credential was rewritten: %q", stored)
+	}
+	// Ensure the foreign value is still recoverable with its own key.
+	if got, ok := decryptAESCore(stored, foreignKey); !ok || got != "secret-of-another-key" {
+		t.Fatalf("foreign credential corrupted: ok=%v got=%q", ok, got)
+	}
+}
+
+// Rows already encrypted with the current key must be skipped so a retried
+// migration is idempotent (P1).
+func TestMigrateLegacyIsIdempotent(t *testing.T) {
+	_, restore := newTestDB(t)
+	defer restore()
+
+	current := encryptAESWithKey("already-current", aesKey)
+	if _, err := db.Exec(`INSERT INTO remote_nodes (ssh_credential) VALUES (?)`, current); err != nil {
+		t.Fatal(err)
+	}
+
+	migrateLegacyCredentials = true
+	migrateLegacyCredentialsIfNeeded()
+
+	var stored string
+	if err := db.QueryRow(`SELECT ssh_credential FROM remote_nodes WHERE id=1`).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(stored, "ENC:") {
+		t.Fatalf("unexpected stored value: %q", stored)
+	}
+	if stored != current {
+		t.Fatalf("already-current row was rewritten: %q", stored)
 	}
 }

--- a/backend/crypto_utils_test.go
+++ b/backend/crypto_utils_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestAESCryptoRoundTrip(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	enc := encryptAESWithKey("topsecret", key)
+	if enc == "topsecret" || len(enc) < 4 || enc[:4] != "ENC:" {
+		t.Fatalf("encrypt did not produce an ENC: payload: %q", enc)
+	}
+	if dec := decryptAESWithKey(enc, key); dec != "topsecret" {
+		t.Fatalf("round-trip failed: got %q", dec)
+	}
+	if d := decryptAESWithKey(enc, []byte("ffffffffffffffffffffffffffffffff")); d == "topsecret" {
+		t.Fatal("decrypt with wrong key leaked plaintext")
+	}
+}
+
+func TestMigrateLegacyCredentialsIfNeeded(t *testing.T) {
+	dir := t.TempDir()
+	tdb, err := sql.Open("sqlite3", filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tdb.Close()
+	if _, err := tdb.Exec(`CREATE TABLE remote_nodes (id INTEGER PRIMARY KEY AUTOINCREMENT, ssh_credential TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+
+	oldDB := db
+	oldKey := aesKey
+	oldMigrate := migrateLegacyCredentials
+	db = tdb
+	newKey := []byte("abcdef0123456789abcdef0123456789")
+	aesKey = newKey
+	defer func() { db = oldDB; aesKey = oldKey; migrateLegacyCredentials = oldMigrate }()
+
+	if _, err := db.Exec(`INSERT INTO remote_nodes (ssh_credential) VALUES (?)`,
+		encryptAESWithKey("legacy-secret", legacyAESKey)); err != nil {
+		t.Fatal(err)
+	}
+	// A plaintext (never-encrypted) value must be left untouched.
+	if _, err := db.Exec(`INSERT INTO remote_nodes (ssh_credential) VALUES (?)`, "plain-legacy"); err != nil {
+		t.Fatal(err)
+	}
+
+	migrateLegacyCredentials = true
+	migrateLegacyCredentialsIfNeeded()
+
+	var enc string
+	if err := db.QueryRow(`SELECT ssh_credential FROM remote_nodes WHERE id=1`).Scan(&enc); err != nil {
+		t.Fatal(err)
+	}
+	if got := decryptAESWithKey(enc, aesKey); got != "legacy-secret" {
+		t.Fatalf("migrated credential not decryptable with new key: got %q", got)
+	}
+	// The new key must differ from the legacy key, so the credential is no
+	// longer decryptable with the well-known constant.
+	if got := decryptAESWithKey(enc, legacyAESKey); got == "legacy-secret" {
+		t.Fatal("migrated credential is still decryptable with the legacy key")
+	}
+
+	var plain string
+	if err := db.QueryRow(`SELECT ssh_credential FROM remote_nodes WHERE id=2`).Scan(&plain); err != nil {
+		t.Fatal(err)
+	}
+	if plain != "plain-legacy" {
+		t.Fatalf("plaintext non-ENC legacy value should be untouched, got %q", plain)
+	}
+}

--- a/backend/db_bootstrap_service.go
+++ b/backend/db_bootstrap_service.go
@@ -163,6 +163,7 @@ func initDB() {
 	purgeDirtyRoutesTable()
 	db.Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
 
+	migrateLegacyCredentialsIfNeeded()
 	ensurePasswordInitialized()
 }
 

--- a/backend/ospf_apply_service.go
+++ b/backend/ospf_apply_service.go
@@ -22,25 +22,30 @@ func applyOspfDeleteBatch(toDel []string) bool {
 		return false
 	}
 	var buf bytes.Buffer
+	applied := make([]string, 0, len(toDel))
 	for _, ip := range toDel {
 		addOspfLog("[DEL] " + ip + " (Miss count >= 3)")
 		routeStr := formatRouteCIDR(ip)
 		if routeStr == "" {
 			continue
 		}
+		applied = append(applied, ip)
 		buf.WriteString(fmt.Sprintf("no ip route %s 127.0.0.1 tag 100\n", routeStr))
+	}
+	if len(applied) == 0 {
+		return false
 	}
 	out, err := runVtyshConfigBatch(buf.String())
 	if err != nil {
-		log.Printf("[FRR] DEL batch=%d apply_failed: %v, out=%q", len(toDel), err, strings.TrimSpace(out))
+		log.Printf("[FRR] DEL batch=%d apply_failed: %v, out=%q", len(applied), err, strings.TrimSpace(out))
 		return false
 	}
 	tx, _ := db.Begin()
-	for _, ip := range toDel {
+	for _, ip := range applied {
 		tx.Exec("DELETE FROM routes_table WHERE ip=?", ip)
 	}
 	tx.Commit()
-	log.Printf("[FRR] DEL batch=%d applied via vtysh", len(toDel))
+	log.Printf("[FRR] DEL batch=%d applied via vtysh", len(applied))
 	return true
 }
 


### PR DESCRIPTION
…ials

The AES init fell back to a hardcoded, publicly-known constant (proxygw-secret-key-32-bytes-long) whenever config/aes.key was missing or DB existed, and persisted it on disk. This made every install share the same key, so SSH credentials stored in SQLite were trivially decryptable from source and defeated the documented AES-256-CFB at-rest encryption.

- crypto_utils: always generate+persist a fresh random key; the legacy constant is used only ONCE to migrate existing rows, never as the long-term key. Also detect installs whose aes.key already holds the legacy constant and rotate them too.
- db_bootstrap: run one-time legacy credential re-encryption after the DB opens.
- ospf_apply: only delete from routes_table the routes that were actually formatted/pushed to FRR (avoid DB/FRR divergence on skipped prefixes).
- app_runtime_shared: give each vtysh batch its own temp file (CreateTemp) so concurrent OSPF applies can no longer clobber a shared path.

Tests: add AES round-trip (wrong-key must not leak) and legacy migration (re-encrypt, no longer decryptable with the old key, plaintext untouched). Full backend suite passes.