### PR TITLE
fix(remote-node): race-safe host-key pin + explicit recovery endpoint (review fixes)

### DIFF
--- a/backend/remote_node_mock_test.go
+++ b/backend/remote_node_mock_test.go
@@ -267,3 +267,79 @@ func TestWrapRemoteCommandWithSudo_RootNoWrap(t *testing.T) {
 		t.Fatalf("expected raw command, got: %s", got)
 	}
 }
+
+func TestPinInitialHostKeyIsConditional(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	repo := NewRemoteNodesRepository()
+
+	// Node 2 is seeded with a pinned key; the conditional pin must not overwrite it.
+	pinned, err := repo.PinInitialHostKey(2, "SHA256:SHOULD-NOT-APPLY")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pinned {
+		t.Fatal("pin must be rejected when a key is already pinned")
+	}
+	var k string
+	if err := db.QueryRow("SELECT ssh_host_key FROM remote_nodes WHERE id=2").Scan(&k); err != nil {
+		t.Fatal(err)
+	}
+	if k != "SHA256:test" {
+		t.Fatalf("stored key was overwritten: %s", k)
+	}
+
+	// Clear the key; the conditional pin should now succeed and store the value.
+	if _, err := db.Exec("UPDATE remote_nodes SET ssh_host_key='' WHERE id=2"); err != nil {
+		t.Fatal(err)
+	}
+	pinned, err = repo.PinInitialHostKey(2, "SHA256:newfp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pinned {
+		t.Fatal("pin should succeed when no key is pinned")
+	}
+	if err := db.QueryRow("SELECT ssh_host_key FROM remote_nodes WHERE id=2").Scan(&k); err != nil {
+		t.Fatal(err)
+	}
+	if k != "SHA256:newfp" {
+		t.Fatalf("pin not stored, got %s", k)
+	}
+}
+
+func postJSON(target, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, target, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestUpdateRemoteNodeHostKeyEndpoint(t *testing.T) {
+	r := setupFeatureSuiteRouter(t)
+	validFP := "SHA256:ADjw2yeU9EmUjcrBrwreHH7cJLe3lNRiPHFhTu3PPio"
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, postJSON("/api/remote_nodes/2/hostkey", `{"ssh_host_key":"garbage"}`))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid fingerprint: want 400 got %d body=%s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, postJSON("/api/remote_nodes/2/hostkey", `{"ssh_host_key":"`+validFP+`"}`))
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid update: want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var k string
+	if err := db.QueryRow("SELECT ssh_host_key FROM remote_nodes WHERE id=2").Scan(&k); err != nil {
+		t.Fatal(err)
+	}
+	if k != validFP {
+		t.Fatalf("host key not updated, got %s", k)
+	}
+
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, postJSON("/api/remote_nodes/999/hostkey", `{"ssh_host_key":"`+validFP+`"}`))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("missing node: want 404 got %d", w.Code)
+	}
+}

--- a/backend/remote_nodes_controller.go
+++ b/backend/remote_nodes_controller.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"log"
 	"net/http"
 	"net/url"
 	"proxygw/remote_deploy"
@@ -80,6 +81,7 @@ func (ctl *RemoteNodesController) RegisterRoutes(authed *gin.RouterGroup) {
 	authed.POST("/remote_nodes", createAndDeployRemoteNode)
 	authed.DELETE("/remote_nodes/:id", deleteRemoteNode)
 	authed.POST("/remote_nodes/:id/check", checkRemoteNode)
+	authed.POST("/remote_nodes/:id/hostkey", updateRemoteNodeHostKey)
 
 	// Advanced Features
 	authed.POST("/remote_nodes/batch", batchDeployRemoteNodes)
@@ -152,6 +154,43 @@ func logAction(nodeId int64, action, status, logText string) {
 
 var hostKeyFingerprintRe = regexp.MustCompile(`SHA256:[A-Za-z0-9+/=_-]+`)
 
+// sshHostKeyFingerprintRe validates an explicit, user-supplied SSH host key
+// fingerprint (as logged by ssh / ssh-keygen, e.g. "SHA256:abc...xyz=").
+var sshHostKeyFingerprintRe = regexp.MustCompile(`^SHA256:[A-Za-z0-9+/=_-]{43,44}$`)
+
+func isValidSSHHostKeyFingerprint(s string) bool {
+	return sshHostKeyFingerprintRe.MatchString(strings.TrimSpace(s))
+}
+
+// updateRemoteNodeHostKey provides an explicit, user-confirmed recovery path
+// for a legitimately rotated host key: instead of silently auto-trusting, the
+// operator verifies the new fingerprint out-of-band and submits it here.
+func updateRemoteNodeHostKey(c *gin.Context) {
+	id := c.Param("id")
+	var req struct {
+		SSHHostKey string `json:"ssh_host_key"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
+		return
+	}
+	fp := strings.TrimSpace(req.SSHHostKey)
+	if !isValidSSHHostKeyFingerprint(fp) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid SSH host key fingerprint (expected SHA256:<base64>)"})
+		return
+	}
+	if _, err := NewRemoteNodesRepository().FetchNodeReq(id); err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Node not found"})
+		return
+	}
+	if err := NewRemoteNodesRepository().SetRemoteNodeHostKey(id, fp); err != nil {
+		log.Printf("[ERR] SetRemoteNodeHostKey: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update host key"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"success": true, "ssh_host_key": fp})
+}
+
 func extractFingerprintFromSSHError(err error) string {
 	if err == nil {
 		return ""
@@ -180,8 +219,16 @@ func connectWithAutoHostKey(id int64, req *RemoteNodeReq) (remoteSSHClient, erro
 		return nil, fmt.Errorf("refusing to auto-trust rotated SSH host key for node %d (stored %s, presented %s): update the pinned host key explicitly to proceed", id, req.SSHHostKey, fp)
 	}
 
-	if uerr := NewRemoteNodesRepository().UpdateRemoteNodeHostKey(id, fp); uerr != nil {
+	// The first routine to reach this point with an empty stored key pins the
+	// fingerprint. The update is conditional on the row still having an empty
+	// key so a concurrent deploy cannot overwrite an already-pinned key with a
+	// different fingerprint (which would reintroduce silent rotation).
+	pinned, uerr := NewRemoteNodesRepository().PinInitialHostKey(id, fp)
+	if uerr != nil {
 		return nil, fmt.Errorf("%v; auto-update host key failed: %v", err, uerr)
+	}
+	if !pinned {
+		return nil, fmt.Errorf("host key for node %d was pinned concurrently by another operation (stored key changed while deploying); refusing to overwrite, retry the deployment", id)
 	}
 	logAction(id, "deploy", "running", fmt.Sprintf("Pinned initial SSH host fingerprint to %s and retrying deployment", fp))
 	req.SSHHostKey = fp

--- a/backend/remote_nodes_repository.go
+++ b/backend/remote_nodes_repository.go
@@ -114,6 +114,26 @@ func (r *RemoteNodesRepository) UpdateRemoteNodeHostKey(id int64, hostKey string
 	return err
 }
 
+// PinInitialHostKey stores hostKey only if the node does not yet have a pinned
+// host key, and reports whether it pinned it. This makes the trust-on-first-use
+// pin race-safe: among concurrent deploys only the first one wins.
+func (r *RemoteNodesRepository) PinInitialHostKey(id int64, hostKey string) (bool, error) {
+	res, err := r.db.Exec("UPDATE remote_nodes SET ssh_host_key = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND (ssh_host_key IS NULL OR ssh_host_key = '')", hostKey, id)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	return n > 0, err
+}
+
+// SetRemoteNodeHostKey is an explicit, user-confirmed update of a verified host
+// key (recovery path for legitimate rotations); unlike PinInitialHostKey it is
+// unconditional.
+func (r *RemoteNodesRepository) SetRemoteNodeHostKey(id, hostKey string) error {
+	_, err := r.db.Exec("UPDATE remote_nodes SET ssh_host_key = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?", hostKey, id)
+	return err
+}
+
 func (r *RemoteNodesRepository) GetRemoteNodeCheckInfo(id string) (RemoteNodeCheckInfo, error) {
 	var info RemoteNodeCheckInfo
 	err := r.db.QueryRow("SELECT ssh_host, ssh_port, ssh_user, ssh_auth_type, ssh_credential, ssh_host_key, type FROM remote_nodes WHERE id = ?", id).


### PR DESCRIPTION
## 说明
针对 PR #10 上 Codex/ChatGPT 的两条 P2 审查意见的修复（基于该分支叠加，合入 #10 后自动改指 `main`）。

## 变更
1. **竞态安全的初始 pin（评论 1）**
   - 原 `UpdateRemoteNodeHostKey` 无条件写入；同一节点并发部署（空 key）时后写者会覆盖先 pin 的指纹，重新引入静默轮换。
   - 改为 `PinInitialHostKey`：`UPDATE ... WHERE id=? AND (ssh_host_key IS NULL OR ssh_host_key='')` + `RowsAffected` 判断，仅首个部署胜出；败者明确失败，不再覆盖。

2. **显式恢复路径（评论 2）**
   - 此前 UU 无法提交「离线核验过的新指纹」（create/batch 不发送 ssh_host_key），轮换后只能删建。
   - 新增 `POST /remote_nodes/:id/hostkey`，校验 `SHA256:` 指纹格式后显式更新 pin，使 `regenerate/rollback` 在主机轮换后恢复可用。

## 测试
- `TestPinInitialHostKeyIsConditional`：已 pin 不可覆写；空 key 才可 pin。
- `TestUpdateRemoteNodeHostKeyEndpoint`：非法指纹 400、成功 200、节点不存在 404。
- `go build` / `go vet` / 全量 `go test ./...` 通过。
