### PR TITLE
ci: add backend CI and fix the data races it exposed

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -42,5 +42,11 @@ jobs:
       - name: Test
         run: go test ./...
 
+      # Non-blocking: the suite currently has pre-existing data races in tests
+      # (global `db`/`remoteConnect` swapped by tests while background goroutines
+      # such as the OSPF sync scheduler still read them). Surfaced here so they
+      # are visible on every run, but do not block merges until fixed.
+      # See https://github.com/zlylong/EdgeRouteGW/issues (data race cleanup).
       - name: Test (race)
+        continue-on-error: true
         run: go test -race ./...

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,46 @@
+name: Backend CI
+
+on:
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      CGO_ENABLED: '1'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Test (race)
+        run: go test -race ./...

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -42,11 +42,5 @@ jobs:
       - name: Test
         run: go test ./...
 
-      # Non-blocking: the suite currently has pre-existing data races in tests
-      # (global `db`/`remoteConnect` swapped by tests while background goroutines
-      # such as the OSPF sync scheduler still read them). Surfaced here so they
-      # are visible on every run, but do not block merges until fixed.
-      # See https://github.com/zlylong/EdgeRouteGW/issues (data race cleanup).
       - name: Test (race)
-        continue-on-error: true
         run: go test -race ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache-dependency-path: backend/go.sum
 
       - name: Install cross-compiler

--- a/backend/api_integration_test.go
+++ b/backend/api_integration_test.go
@@ -47,7 +47,7 @@ func setupTestRouter(t *testing.T) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	tdb, _ := setupTestDB(t)
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() {
 		db.Close()
 	})

--- a/backend/app_runtime_shared.go
+++ b/backend/app_runtime_shared.go
@@ -17,6 +17,20 @@ var (
 	cacheMutex    sync.Mutex
 )
 
+var dbMu sync.RWMutex
+
+func getDB() *sql.DB {
+	dbMu.RLock()
+	defer dbMu.RUnlock()
+	return db
+}
+
+func setDB(d *sql.DB) {
+	dbMu.Lock()
+	db = d
+	dbMu.Unlock()
+}
+
 // goSafe runs fn in a goroutine with panic recovery, logging the stack trace.
 // Use this instead of bare "go fn()" for all background goroutines.
 func goSafe(fn func()) {

--- a/backend/app_runtime_shared.go
+++ b/backend/app_runtime_shared.go
@@ -137,7 +137,7 @@ func clampOspfResolveWorkers(v int) int {
 func readIntSettingWithDefault(key string, fallback int, clamp func(int) int) int {
 	value := fallback
 	var raw string
-	err := db.QueryRow("SELECT value FROM settings WHERE key=?", key).Scan(&raw)
+	err := getDB().QueryRow("SELECT value FROM settings WHERE key=?", key).Scan(&raw)
 	switch {
 	case err == nil:
 		if parsed, parseErr := strconv.Atoi(strings.TrimSpace(raw)); parseErr == nil {
@@ -149,7 +149,7 @@ func readIntSettingWithDefault(key string, fallback int, clamp func(int) int) in
 	if clamp != nil {
 		value = clamp(value)
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", key, strconv.Itoa(value)); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", key, strconv.Itoa(value)); err != nil {
 		log.Printf("[WARN] persist default setting %s failed: %v", key, err)
 	}
 	return value

--- a/backend/auth_controller.go
+++ b/backend/auth_controller.go
@@ -100,7 +100,7 @@ func (ctl *AuthController) ChangePassword(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "hash error"})
 		return
 	}
-	tx, err := db.Begin()
+	tx, err := getDB().Begin()
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "db error"})
 		return

--- a/backend/auth_service.go
+++ b/backend/auth_service.go
@@ -83,7 +83,7 @@ func hashPassword(password string) (string, error) {
 
 func verifyAndMaybeMigratePassword(input string) (bool, error) {
 	var hash string
-	err := db.QueryRow("SELECT value FROM settings WHERE key='password_hash'").Scan(&hash)
+	err := getDB().QueryRow("SELECT value FROM settings WHERE key='password_hash'").Scan(&hash)
 	if err != nil && err != sql.ErrNoRows {
 		return false, err
 	}
@@ -96,7 +96,7 @@ func verifyAndMaybeMigratePassword(input string) (bool, error) {
 	}
 
 	var legacyPwd string
-	err = db.QueryRow("SELECT value FROM settings WHERE key='password'").Scan(&legacyPwd)
+	err = getDB().QueryRow("SELECT value FROM settings WHERE key='password'").Scan(&legacyPwd)
 	if err != nil && err != sql.ErrNoRows {
 		return false, err
 	}
@@ -108,7 +108,7 @@ func verifyAndMaybeMigratePassword(input string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	tx, err := db.Begin()
+	tx, err := getDB().Begin()
 	if err != nil {
 		return false, err
 	}

--- a/backend/connection_tracker.go
+++ b/backend/connection_tracker.go
@@ -219,7 +219,7 @@ func lookupRecentDomainByIP(ip string) string {
 		return ""
 	}
 	var domain string
-	if err := db.QueryRow(
+	if err := getDB().QueryRow(
 		"SELECT COALESCE(domain, '') FROM routes_table WHERE (ip=? OR ip=? || '/32') AND COALESCE(domain, '') <> '' ORDER BY CASE WHEN ip=? THEN 0 ELSE 1 END, datetime(last_seen) DESC LIMIT 1",
 		ip, ip, ip,
 	).Scan(&domain); err == nil {
@@ -234,7 +234,7 @@ func lookupRecentDomainByIPFromResolveCache(ip string) string {
 		return ""
 	}
 	var domain string
-	if err := db.QueryRow(
+	if err := getDB().QueryRow(
 		"SELECT COALESCE(domain, '') FROM domain_resolve_cache WHERE ips_json LIKE '%' || char(34) || ? || char(34) || '%' ORDER BY CAST(COALESCE(resolved_at, '0') AS INTEGER) DESC LIMIT 1",
 		ip,
 	).Scan(&domain); err != nil {
@@ -296,7 +296,7 @@ func policyMatchesConnection(rulePolicy, connPolicy string) bool {
 }
 
 func attachRuleMatchMeta(records []ConnectionRecord) []ConnectionRecord {
-	rows, err := db.Query("SELECT id, type, value, policy FROM rules ORDER BY priority ASC, id ASC")
+	rows, err := getDB().Query("SELECT id, type, value, policy FROM rules ORDER BY priority ASC, id ASC")
 	if err != nil {
 		return records
 	}

--- a/backend/connection_tracker_domain_resolve_cache_test.go
+++ b/backend/connection_tracker_domain_resolve_cache_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestLookupRecentDomainByIPFromResolveCache(t *testing.T) {
 	tdb, _ := setupTestDB(t)
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() { db.Close() })
 
 	if _, err := db.Exec(`

--- a/backend/connection_tracker_geosite_association_test.go
+++ b/backend/connection_tracker_geosite_association_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestAttachRuleMatchMetaDomainByResolveCache(t *testing.T) {
 	tdb, _ := setupTestDB(t)
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() { db.Close() })
 
 	if _, err := db.Exec(`

--- a/backend/connection_tracker_unmatched_reason_test.go
+++ b/backend/connection_tracker_unmatched_reason_test.go
@@ -17,7 +17,7 @@ func ensureConnectionTrackerLookupTables(t *testing.T) {
 
 func TestAttachRuleMatchMeta_UnmatchedReason_NoPolicyMatch(t *testing.T) {
 	tdb, _ := setupTestDB(t)
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() { db.Close() })
 	ensureConnectionTrackerLookupTables(t)
 
@@ -45,7 +45,7 @@ func TestAttachRuleMatchMeta_UnmatchedReason_NoPolicyMatch(t *testing.T) {
 
 func TestAttachRuleMatchMeta_UnmatchedReason_IPWithoutDomainBackfill(t *testing.T) {
 	tdb, _ := setupTestDB(t)
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() { db.Close() })
 	ensureConnectionTrackerLookupTables(t)
 

--- a/backend/cron_domain_service.go
+++ b/backend/cron_domain_service.go
@@ -91,19 +91,19 @@ func calcNextCronRun(now time.Time, scheduleType string, hour int, minute int, w
 func loadCronScheduleSettings() cronScheduleSettings {
 	cfg := cronScheduleSettings{Enabled: false, Time: "04:00", ScheduleType: "daily", Weekday: 1, Monthday: 1}
 	var enabled, cronTime, scheduleType, weekday, monthday string
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='cron_enabled'").Scan(&enabled); err != nil && err != sql.ErrNoRows {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='cron_enabled'").Scan(&enabled); err != nil && err != sql.ErrNoRows {
 		log.Printf("[WARN] cron_enabled check err: %v", err)
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='cron_time'").Scan(&cronTime); err != nil && err != sql.ErrNoRows {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='cron_time'").Scan(&cronTime); err != nil && err != sql.ErrNoRows {
 		log.Printf("[WARN] cron_time check err: %v", err)
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='cron_schedule_type'").Scan(&scheduleType); err != nil && err != sql.ErrNoRows {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='cron_schedule_type'").Scan(&scheduleType); err != nil && err != sql.ErrNoRows {
 		log.Printf("[WARN] cron_schedule_type check err: %v", err)
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='cron_weekday'").Scan(&weekday); err != nil && err != sql.ErrNoRows {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='cron_weekday'").Scan(&weekday); err != nil && err != sql.ErrNoRows {
 		log.Printf("[WARN] cron_weekday check err: %v", err)
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='cron_monthday'").Scan(&monthday); err != nil && err != sql.ErrNoRows {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='cron_monthday'").Scan(&monthday); err != nil && err != sql.ErrNoRows {
 		log.Printf("[WARN] cron_monthday check err: %v", err)
 	}
 	cfg.Enabled = strings.TrimSpace(enabled) == "true"
@@ -193,7 +193,7 @@ func domainIPUpdater() {
 	ticker := time.NewTicker(5 * time.Minute)
 	for range ticker.C {
 		var mode string
-		if err := db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil {
+		if err := getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil {
 			mode = "A"
 		}
 		if mode == "C" {

--- a/backend/crypto_utils.go
+++ b/backend/crypto_utils.go
@@ -76,7 +76,7 @@ func migrateLegacyCredentialsIfNeeded() {
 	}
 	migrateLegacyCredentials = false
 
-	rows, err := db.Query("SELECT id, ssh_credential FROM remote_nodes")
+	rows, err := getDB().Query("SELECT id, ssh_credential FROM remote_nodes")
 	if err != nil {
 		log.Printf("[SECURITY] migrate legacy credentials: query failed: %v", err)
 		return
@@ -117,7 +117,7 @@ func migrateLegacyCredentialsIfNeeded() {
 	rows.Close()
 
 	if len(updates) > 0 {
-		tx, err := db.Begin()
+		tx, err := getDB().Begin()
 		if err != nil {
 			log.Printf("[SECURITY] migrate legacy credentials: begin tx failed: %v", err)
 			return

--- a/backend/crypto_utils_test.go
+++ b/backend/crypto_utils_test.go
@@ -36,9 +36,9 @@ func newTestDB(t *testing.T) (*sql.DB, func()) {
 	oldDB := db
 	oldKey := aesKey
 	oldMigrate := migrateLegacyCredentials
-	db = tdb
+	setDB(tdb)
 	aesKey = []byte("abcdef0123456789abcdef0123456789")
-	return tdb, func() { tdb.Close(); db = oldDB; aesKey = oldKey; migrateLegacyCredentials = oldMigrate }
+	return tdb, func() { tdb.Close(); setDB(oldDB); aesKey = oldKey; migrateLegacyCredentials = oldMigrate }
 }
 
 func TestMigrateLegacyCredentialsIfNeeded(t *testing.T) {

--- a/backend/db_bootstrap_service.go
+++ b/backend/db_bootstrap_service.go
@@ -17,9 +17,9 @@ func initDB() {
 	}
 
 	// Enable WAL mode for high concurrency
-	db.Exec("PRAGMA journal_mode=WAL;")
-	db.Exec("PRAGMA synchronous=NORMAL;")
-	db.Exec("PRAGMA busy_timeout=5000;")
+	getDB().Exec("PRAGMA journal_mode=WAL;")
+	getDB().Exec("PRAGMA synchronous=NORMAL;")
+	getDB().Exec("PRAGMA busy_timeout=5000;")
 
 	tables := []string{
 
@@ -67,108 +67,108 @@ func initDB() {
 		);`,
 	}
 	for _, t := range tables {
-		if _, err := db.Exec(t); err != nil {
+		if _, err := getDB().Exec(t); err != nil {
 			log.Fatalf("[FATAL] failed to create table: %v", err)
 		}
 	}
-	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS protected_ips (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL UNIQUE, remark TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP)"); err != nil {
+	if _, err := getDB().Exec("CREATE TABLE IF NOT EXISTS protected_ips (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL UNIQUE, remark TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP)"); err != nil {
 		log.Fatalf("[FATAL] failed to create protected_ips table: %v", err)
 	}
 	ensureGatewayEventTable()
 
-	if _, err := db.Exec("ALTER TABLE nodes ADD COLUMN params TEXT DEFAULT '{}'"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+	if _, err := getDB().Exec("ALTER TABLE nodes ADD COLUMN params TEXT DEFAULT '{}'"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		log.Printf("[WARN] ALTER TABLE failed: %v", err)
 	}
 
-	if _, err := db.Exec("ALTER TABLE remote_nodes ADD COLUMN ssh_host_key TEXT DEFAULT ''"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+	if _, err := getDB().Exec("ALTER TABLE remote_nodes ADD COLUMN ssh_host_key TEXT DEFAULT ''"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		log.Printf("[WARN] ALTER TABLE failed: %v", err)
 	}
-	if _, err := db.Exec("ALTER TABLE nodes ADD COLUMN ping INTEGER DEFAULT 0"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+	if _, err := getDB().Exec("ALTER TABLE nodes ADD COLUMN ping INTEGER DEFAULT 0"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		log.Printf("[WARN] ALTER TABLE failed: %v", err)
 	}
-	if _, err := db.Exec("ALTER TABLE routes_table ADD COLUMN miss_count INTEGER DEFAULT 0"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+	if _, err := getDB().Exec("ALTER TABLE routes_table ADD COLUMN miss_count INTEGER DEFAULT 0"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		log.Printf("[WARN] ALTER TABLE failed: %v", err)
 	}
-	if _, err := db.Exec("ALTER TABLE rules ADD COLUMN priority INTEGER NOT NULL DEFAULT 0"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+	if _, err := getDB().Exec("ALTER TABLE rules ADD COLUMN priority INTEGER NOT NULL DEFAULT 0"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		log.Printf("[WARN] ALTER TABLE failed: %v", err)
 	}
-	if _, err := db.Exec("UPDATE rules SET priority=id WHERE priority=0"); err != nil {
+	if _, err := getDB().Exec("UPDATE rules SET priority=id WHERE priority=0"); err != nil {
 		log.Printf("[WARN] rules priority backfill failed: %v", err)
 	}
-	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_rules_priority_id ON rules(priority ASC, id ASC)"); err != nil {
+	if _, err := getDB().Exec("CREATE INDEX IF NOT EXISTS idx_rules_priority_id ON rules(priority ASC, id ASC)"); err != nil {
 		log.Printf("[WARN] create rules priority index failed: %v", err)
 	}
-	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_routes_status_firstseen ON routes_table(status, first_seen)"); err != nil {
+	if _, err := getDB().Exec("CREATE INDEX IF NOT EXISTS idx_routes_status_firstseen ON routes_table(status, first_seen)"); err != nil {
 		log.Printf("[WARN] create routes status+first_seen index failed: %v", err)
 	}
-	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_routes_status_misscount ON routes_table(status, miss_count)"); err != nil {
+	if _, err := getDB().Exec("CREATE INDEX IF NOT EXISTS idx_routes_status_misscount ON routes_table(status, miss_count)"); err != nil {
 		log.Printf("[WARN] create routes status+miss_count index failed: %v", err)
 	}
-	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_gateway_events_ts ON gateway_events(ts)"); err != nil {
+	if _, err := getDB().Exec("CREATE INDEX IF NOT EXISTS idx_gateway_events_ts ON gateway_events(ts)"); err != nil {
 		log.Printf("[WARN] create gateway_events ts index failed: %v", err)
 	}
-	if _, err := db.Exec("CREATE INDEX IF NOT EXISTS idx_node_traffic_history_ts_node ON node_traffic_history(ts, node_id)"); err != nil {
+	if _, err := getDB().Exec("CREATE INDEX IF NOT EXISTS idx_node_traffic_history_ts_node ON node_traffic_history(ts, node_id)"); err != nil {
 		log.Printf("[WARN] create node_traffic_history ts+node_id index failed: %v", err)
 	}
-	if _, err := db.Exec("ALTER TABLE rules ADD COLUMN group_id TEXT NOT NULL DEFAULT ''"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+	if _, err := getDB().Exec("ALTER TABLE rules ADD COLUMN group_id TEXT NOT NULL DEFAULT ''"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		log.Printf("[WARN] ALTER TABLE failed: %v", err)
 	}
-	if _, err := db.Exec("ALTER TABLE rules ADD COLUMN group_name TEXT NOT NULL DEFAULT ''"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
+	if _, err := getDB().Exec("ALTER TABLE rules ADD COLUMN group_name TEXT NOT NULL DEFAULT ''"); err != nil && !strings.Contains(err.Error(), "duplicate column name") {
 		log.Printf("[WARN] ALTER TABLE failed: %v", err)
 	}
 
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('mode', 'B')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('mode', 'B')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('dns_local', '119.29.29.29,223.5.5.5')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('dns_local', '119.29.29.29,223.5.5.5')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('dns_remote', '1.1.1.1,8.8.8.8')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('dns_remote', '1.1.1.1,8.8.8.8')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('dns_lazy', 'true')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('dns_lazy', 'true')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('dns_mode', 'smart')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('dns_mode', 'smart')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_enabled', 'true')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_enabled', 'true')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_time', '04:00')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_time', '04:00')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_schedule_type', 'daily')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_schedule_type', 'daily')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_weekday', '1')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_weekday', '1')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_monthday', '1')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('cron_monthday', '1')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('ospf_push_batch_limit', '500')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('ospf_push_batch_limit', '500')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('ospf_push_interval_seconds', '10')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('ospf_push_interval_seconds', '10')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('ospf_resolve_workers', '16')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('ospf_resolve_workers', '16')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
-	if _, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('lan_default_policy', 'proxy')"); err != nil {
+	if _, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES ('lan_default_policy', 'proxy')"); err != nil {
 		log.Printf("[WARN] default data insert failed: %v", err)
 	}
 
 	purgeDirtyRoutesTable()
-	db.Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
+	getDB().Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
 
 	migrateLegacyCredentialsIfNeeded()
 	ensurePasswordInitialized()
 }
 
 func purgeDirtyRoutesTable() {
-	rows, err := db.Query("SELECT ip FROM routes_table")
+	rows, err := getDB().Query("SELECT ip FROM routes_table")
 	if err != nil {
 		log.Printf("[WARN] purge dirty routes query failed: %v", err)
 		return
@@ -189,7 +189,7 @@ func purgeDirtyRoutesTable() {
 		return
 	}
 
-	tx, err := db.Begin()
+	tx, err := getDB().Begin()
 	if err != nil {
 		log.Printf("[WARN] purge dirty routes begin tx failed: %v", err)
 		return
@@ -210,11 +210,11 @@ func purgeDirtyRoutesTable() {
 
 func ensurePasswordInitialized() {
 	var pwdHash, legacyPwd string
-	err := db.QueryRow("SELECT value FROM settings WHERE key='password_hash'").Scan(&pwdHash)
+	err := getDB().QueryRow("SELECT value FROM settings WHERE key='password_hash'").Scan(&pwdHash)
 	if err != nil && err != sql.ErrNoRows {
 		log.Printf("[WARN] get password_hash err: %v", err)
 	}
-	err = db.QueryRow("SELECT value FROM settings WHERE key='password'").Scan(&legacyPwd)
+	err = getDB().QueryRow("SELECT value FROM settings WHERE key='password'").Scan(&legacyPwd)
 	if err != nil && err != sql.ErrNoRows {
 		log.Printf("[WARN] get legacy pwd err: %v", err)
 	}
@@ -241,7 +241,7 @@ func ensurePasswordInitialized() {
 		log.Printf("[SECURITY] password bootstrap hash failed: %v", err)
 		return
 	}
-	if _, err = db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('password_hash', ?)", hash); err != nil {
+	if _, err = getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('password_hash', ?)", hash); err != nil {
 		log.Printf("[SECURITY] password bootstrap db write failed: %v", err)
 		return
 	}

--- a/backend/db_maintenance.go
+++ b/backend/db_maintenance.go
@@ -93,7 +93,7 @@ func performDBPruning() {
 	}
 
 	for _, q := range queries {
-		res, err := db.Exec(q.sql)
+		res, err := getDB().Exec(q.sql)
 		if err != nil {
 			log.Printf("[MAINTENANCE] Failed to prune %s: %v", q.name, err)
 			continue
@@ -107,10 +107,10 @@ func performDBPruning() {
 	// Optimize the database occasionally
 	if time.Now().Weekday() == time.Sunday {
 		log.Println("[MAINTENANCE] Performing weekly database optimization (VACUUM/ANALYZE)...")
-		if _, err := db.Exec("VACUUM"); err != nil {
+		if _, err := getDB().Exec("VACUUM"); err != nil {
 			log.Printf("[MAINTENANCE] VACUUM failed: %v", err)
 		}
-		if _, err := db.Exec("ANALYZE"); err != nil {
+		if _, err := getDB().Exec("ANALYZE"); err != nil {
 			log.Printf("[MAINTENANCE] ANALYZE failed: %v", err)
 		}
 	}

--- a/backend/dns_controller.go
+++ b/backend/dns_controller.go
@@ -98,7 +98,7 @@ func (ctl *DNSController) SetDNS(c *gin.Context) {
 		return
 	}
 	// Clear domain resolve cache to ensure new DNS settings take effect for OSPF
-	_, _ = db.Exec("DELETE FROM domain_resolve_cache")
+	_, _ = getDB().Exec("DELETE FROM domain_resolve_cache")
 	log.Println("[INFO] Cleared domain_resolve_cache due to DNS settings update")
 
 	c.JSON(http.StatusOK, gin.H{

--- a/backend/dns_repository.go
+++ b/backend/dns_repository.go
@@ -11,22 +11,22 @@ func NewDNSRepository() *DNSRepository { return &DNSRepository{} }
 
 func (r *DNSRepository) GetSetting(key string) (string, error) {
 	var value string
-	err := db.QueryRow("SELECT value FROM settings WHERE key=?", key).Scan(&value)
+	err := getDB().QueryRow("SELECT value FROM settings WHERE key=?", key).Scan(&value)
 	return value, err
 }
 
 func (r *DNSRepository) InsertIgnoreSetting(key, value string) error {
-	_, err := db.Exec("INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)", key, value)
+	_, err := getDB().Exec("INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)", key, value)
 	return err
 }
 
 func (r *DNSRepository) UpdateSetting(key, value string) error {
-	_, err := db.Exec("UPDATE settings SET value=? WHERE key=?", value, key)
+	_, err := getDB().Exec("UPDATE settings SET value=? WHERE key=?", value, key)
 	return err
 }
 
 func (r *DNSRepository) UpsertSetting(key, value string) error {
-	_, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", key, value)
+	_, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", key, value)
 	return err
 }
 

--- a/backend/event_logs.go
+++ b/backend/event_logs.go
@@ -38,7 +38,7 @@ var (
 )
 
 func ensureGatewayEventTable() {
-	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS gateway_events (
+	if _, err := getDB().Exec(`CREATE TABLE IF NOT EXISTS gateway_events (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		ts DATETIME DEFAULT CURRENT_TIMESTAMP,
 		level TEXT NOT NULL,
@@ -56,13 +56,13 @@ func ensureGatewayEventTable() {
 		log.Printf("[WARN] create gateway_events failed: %v", err)
 		return
 	}
-	if _, err := db.Exec(`DELETE FROM gateway_events WHERE ts < datetime('now', '-30 days')`); err != nil {
+	if _, err := getDB().Exec(`DELETE FROM gateway_events WHERE ts < datetime('now', '-30 days')`); err != nil {
 		log.Printf("[WARN] prune gateway_events failed: %v", err)
 	}
 }
 
 func logGatewayEvent(level, module, eventType, message string, fields map[string]interface{}) {
-	if db == nil {
+	if getDB() == nil {
 		return
 	}
 	traceID := ""
@@ -121,7 +121,7 @@ func logGatewayEvent(level, module, eventType, message string, fields map[string
 		}
 	}
 
-	if _, err := db.Exec(`INSERT INTO gateway_events (level, module, event_type, message, trace_id, source_ip, method, path, status, duration_ms, details_json)
+	if _, err := getDB().Exec(`INSERT INTO gateway_events (level, module, event_type, message, trace_id, source_ip, method, path, status, duration_ms, details_json)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		strings.ToLower(strings.TrimSpace(level)),
 		strings.TrimSpace(module),
@@ -233,7 +233,7 @@ func registerEventRoutes(r *gin.RouterGroup) {
 		baseSQL += " ORDER BY id DESC LIMIT ?"
 		args = append(args, limit)
 
-		rows, err := db.Query(baseSQL, args...)
+		rows, err := getDB().Query(baseSQL, args...)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "query gateway_events failed"})
 			return

--- a/backend/feature_suite_test.go
+++ b/backend/feature_suite_test.go
@@ -60,14 +60,14 @@ func setupFeatureSuiteRouter(t *testing.T) *gin.Engine {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() {
 		applyMutex.Lock()
 		if applyTimer != nil {
 			applyTimer.Stop()
 			applyTimer = nil
 		}
-		db = oldDB
+		setDB(oldDB)
 		cachedGeosite = oldCachedGeosite
 		cachedGeoip = oldCachedGeoip
 		ospfLogs = oldOspfLogs

--- a/backend/lan_acl_repository.go
+++ b/backend/lan_acl_repository.go
@@ -14,7 +14,7 @@ type LanACLRecord struct {
 func NewLanACLRepository() *LanACLRepository { return &LanACLRepository{} }
 
 func (r *LanACLRepository) List() ([]LanACLRecord, error) {
-	rows, err := db.Query("SELECT id, type, value, policy, remark, created_at FROM lan_acls ORDER BY id DESC")
+	rows, err := getDB().Query("SELECT id, type, value, policy, remark, created_at FROM lan_acls ORDER BY id DESC")
 	if err != nil {
 		return nil, err
 	}
@@ -33,23 +33,23 @@ func (r *LanACLRepository) List() ([]LanACLRecord, error) {
 
 func (r *LanACLRepository) GetDefaultPolicy() string {
 	var defaultPolicy string
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil {
 		return "proxy"
 	}
 	return defaultPolicy
 }
 
 func (r *LanACLRepository) Create(typ, value, policy, remark string) error {
-	_, err := db.Exec("INSERT INTO lan_acls (type, value, policy, remark) VALUES (?, ?, ?, ?)", typ, value, policy, remark)
+	_, err := getDB().Exec("INSERT INTO lan_acls (type, value, policy, remark) VALUES (?, ?, ?, ?)", typ, value, policy, remark)
 	return err
 }
 
 func (r *LanACLRepository) Delete(id string) error {
-	_, err := db.Exec("DELETE FROM lan_acls WHERE id=?", id)
+	_, err := getDB().Exec("DELETE FROM lan_acls WHERE id=?", id)
 	return err
 }
 
 func (r *LanACLRepository) SetDefaultPolicy(policy string) error {
-	_, err := db.Exec("UPDATE settings SET value=? WHERE key='lan_default_policy'", policy)
+	_, err := getDB().Exec("UPDATE settings SET value=? WHERE key='lan_default_policy'", policy)
 	return err
 }

--- a/backend/mosdns_proxy_domains_test.go
+++ b/backend/mosdns_proxy_domains_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestBuildMosdnsProxyDomainsIncludesGeositeDomains(t *testing.T) {
 	tdb, _ := setupTestDB(t)
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() { db.Close() })
 
 	if _, err := db.Exec("DELETE FROM rules"); err != nil {

--- a/backend/mosdns_runtime_service.go
+++ b/backend/mosdns_runtime_service.go
@@ -47,7 +47,7 @@ func buildMosdnsProxyDomains(mode string) ([]string, error) {
 		proxyDomains = append(proxyDomains, domain)
 	}
 
-	dRows, err := db.Query("SELECT value FROM rules WHERE type='domain' AND policy LIKE 'proxy%'")
+	dRows, err := getDB().Query("SELECT value FROM rules WHERE type='domain' AND policy LIKE 'proxy%'")
 	if err != nil {
 		return nil, fmt.Errorf("query domain rules failed: %w", err)
 	}
@@ -68,7 +68,7 @@ func buildMosdnsProxyDomains(mode string) ([]string, error) {
 	}
 	dRows.Close()
 
-	gRows, err := db.Query("SELECT value FROM rules WHERE type='geosite' AND policy LIKE 'proxy%'")
+	gRows, err := getDB().Query("SELECT value FROM rules WHERE type='geosite' AND policy LIKE 'proxy%'")
 	if err != nil {
 		return nil, fmt.Errorf("query geosite rules failed: %w", err)
 	}
@@ -128,22 +128,22 @@ func applyMosdnsConfig() error {
 	log.Println("[AUDIT] Applying Mosdns Config")
 	var local, remote, lazyStr, logLevel, cacheSizeStr, lazyTTLStr string
 
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='dns_local'").Scan(&local); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='dns_local'").Scan(&local); err != nil {
 		local = "119.29.29.29,223.5.5.5"
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='dns_remote'").Scan(&remote); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='dns_remote'").Scan(&remote); err != nil {
 		remote = "1.1.1.1,8.8.8.8"
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='dns_lazy'").Scan(&lazyStr); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='dns_lazy'").Scan(&lazyStr); err != nil {
 		lazyStr = "true"
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='dns_log_level'").Scan(&logLevel); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='dns_log_level'").Scan(&logLevel); err != nil {
 		logLevel = "info"
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='dns_cache_size'").Scan(&cacheSizeStr); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='dns_cache_size'").Scan(&cacheSizeStr); err != nil {
 		cacheSizeStr = "10240"
 	}
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='dns_lazy_ttl'").Scan(&lazyTTLStr); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='dns_lazy_ttl'").Scan(&lazyTTLStr); err != nil {
 		lazyTTLStr = "86400"
 	}
 
@@ -151,7 +151,7 @@ func applyMosdnsConfig() error {
 	lazyTTL, _ := strconv.Atoi(lazyTTLStr)
 
 	var mode string
-	db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
+	getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
 	proxyDomains, err := buildMosdnsProxyDomains(mode)
 	if err != nil {
 		return err

--- a/backend/network_iface_service.go
+++ b/backend/network_iface_service.go
@@ -8,8 +8,8 @@ import (
 
 func getPrimaryLANIPAndSubnet() (string, string) {
 	serviceIface := ""
-	if db != nil {
-		_ = db.QueryRow("SELECT value FROM settings WHERE key='service_iface'").Scan(&serviceIface)
+	if getDB() != nil {
+		_ = getDB().QueryRow("SELECT value FROM settings WHERE key='service_iface'").Scan(&serviceIface)
 		serviceIface = strings.TrimSpace(serviceIface)
 	}
 

--- a/backend/nftables_service.go
+++ b/backend/nftables_service.go
@@ -94,12 +94,12 @@ table inet proxygw {
 
 func applyNftablesConfig() error {
 	var defaultPolicy string
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil {
 		defaultPolicy = "proxy"
 	}
 
 	var mode string
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil {
 		mode = "A" // default
 	}
 
@@ -110,7 +110,7 @@ func applyNftablesConfig() error {
 	if mode == "A" {
 
 		// Mode A protected IP list: always direct, to avoid disconnect during xray rule reload
-		if rows, err := db.Query("SELECT value FROM protected_ips ORDER BY id"); err == nil {
+		if rows, err := getDB().Query("SELECT value FROM protected_ips ORDER BY id"); err == nil {
 			defer rows.Close()
 			for rows.Next() {
 				var v string
@@ -126,7 +126,7 @@ func applyNftablesConfig() error {
 				}
 			}
 		}
-		rows, err := db.Query("SELECT type, value, policy FROM lan_acls")
+		rows, err := getDB().Query("SELECT type, value, policy FROM lan_acls")
 		if err == nil {
 			defer rows.Close()
 			for rows.Next() {

--- a/backend/nodes_repository.go
+++ b/backend/nodes_repository.go
@@ -8,13 +8,13 @@ func NewNodesRepository() *NodesRepository { return &NodesRepository{} }
 
 func (r *NodesRepository) GetDefaultNodeID() (string, error) {
 	var value string
-	err := db.QueryRow("SELECT value FROM settings WHERE key='default_node_id'").Scan(&value)
+	err := getDB().QueryRow("SELECT value FROM settings WHERE key='default_node_id'").Scan(&value)
 	return value, err
 }
 
 func (r *NodesRepository) GetNodeFailoverMode() (string, error) {
 	var value string
-	err := db.QueryRow("SELECT value FROM settings WHERE key='node_failover_mode'").Scan(&value)
+	err := getDB().QueryRow("SELECT value FROM settings WHERE key='node_failover_mode'").Scan(&value)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return "normal", nil
@@ -25,16 +25,16 @@ func (r *NodesRepository) GetNodeFailoverMode() (string, error) {
 }
 
 func (r *NodesRepository) ListNodes() (*sql.Rows, error) {
-	return db.Query("SELECT id, name, grp, type, address, port, uuid, active, ping, COALESCE(params, '{}') FROM nodes")
+	return getDB().Query("SELECT id, name, grp, type, address, port, uuid, active, ping, COALESCE(params, '{}') FROM nodes")
 }
 
 func (r *NodesRepository) SetDefaultNodeID(id string) error {
-	_, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('default_node_id', ?)", id)
+	_, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('default_node_id', ?)", id)
 	return err
 }
 
 func (r *NodesRepository) SetNodeFailoverMode(mode string) error {
-	_, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('node_failover_mode', ?)", normalizeNodeFailoverMode(mode))
+	_, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('node_failover_mode', ?)", normalizeNodeFailoverMode(mode))
 	return err
 }
 
@@ -46,30 +46,30 @@ func normalizeNodeFailoverMode(mode string) string {
 }
 
 func (r *NodesRepository) InsertNode(name, groupName, nodeType, address string, port int, uuid, params string) error {
-	_, err := db.Exec("INSERT INTO nodes (name, grp, type, address, port, uuid, params, active) VALUES (?, ?, ?, ?, ?, ?, ?, 1)", name, groupName, nodeType, address, port, uuid, params)
+	_, err := getDB().Exec("INSERT INTO nodes (name, grp, type, address, port, uuid, params, active) VALUES (?, ?, ?, ?, ?, ?, ?, 1)", name, groupName, nodeType, address, port, uuid, params)
 	return err
 }
 
 func (r *NodesRepository) ListPingTargets() (*sql.Rows, error) {
-	return db.Query("SELECT id, type, address, port FROM nodes")
+	return getDB().Query("SELECT id, type, address, port FROM nodes")
 }
 
 func (r *NodesRepository) UpdateNodePing(id int, ping int) error {
-	_, err := db.Exec("UPDATE nodes SET ping=? WHERE id=?", ping, id)
+	_, err := getDB().Exec("UPDATE nodes SET ping=? WHERE id=?", ping, id)
 	return err
 }
 
 func (r *NodesRepository) UpdateNodeByID(id, name, groupName, nodeType, address string, port int, uuid, params string) error {
-	_, err := db.Exec("UPDATE nodes SET name=?, grp=?, type=?, address=?, port=?, uuid=?, params=? WHERE id=?", name, groupName, nodeType, address, port, uuid, params, id)
+	_, err := getDB().Exec("UPDATE nodes SET name=?, grp=?, type=?, address=?, port=?, uuid=?, params=? WHERE id=?", name, groupName, nodeType, address, port, uuid, params, id)
 	return err
 }
 
 func (r *NodesRepository) DeleteNodeByID(id string) error {
-	_, err := db.Exec("DELETE FROM nodes WHERE id=?", id)
+	_, err := getDB().Exec("DELETE FROM nodes WHERE id=?", id)
 	return err
 }
 
 func (r *NodesRepository) ToggleNodeByID(id string) error {
-	_, err := db.Exec("UPDATE nodes SET active = NOT active WHERE id=?", id)
+	_, err := getDB().Exec("UPDATE nodes SET active = NOT active WHERE id=?", id)
 	return err
 }

--- a/backend/ospf_apply_service.go
+++ b/backend/ospf_apply_service.go
@@ -40,7 +40,7 @@ func applyOspfDeleteBatch(toDel []string) bool {
 		log.Printf("[FRR] DEL batch=%d apply_failed: %v, out=%q", len(applied), err, strings.TrimSpace(out))
 		return false
 	}
-	tx, _ := db.Begin()
+	tx, _ := getDB().Begin()
 	for _, ip := range applied {
 		tx.Exec("DELETE FROM routes_table WHERE ip=?", ip)
 	}
@@ -81,7 +81,7 @@ func applyOspfAddBatch(toAdd []string) bool {
 			log.Printf("[FRR] ADD blocked by ospf publish allowlist: requested=%d skipped=%d", len(toAdd), skipped)
 			// GC blocked candidates: if a candidate is blocked by policy/allowlist,
 			// mark it as 'failed_policy' so it doesn't stay in 'candidate' forever.
-			tx, _ := db.Begin()
+			tx, _ := getDB().Begin()
 			for _, ip := range toAdd {
 				// We don't want to keep retrying these in every sync cycle
 				tx.Exec("UPDATE routes_table SET status='failed_policy', miss_count=miss_count+1 WHERE ip=? AND status='candidate'", ip)
@@ -95,7 +95,7 @@ func applyOspfAddBatch(toAdd []string) bool {
 		log.Printf("[FRR] ADD batch=%d apply_failed: %v, out=%q", len(allowed), err, strings.TrimSpace(out))
 		return false
 	}
-	tx, _ := db.Begin()
+	tx, _ := getDB().Begin()
 	for _, ip := range allowed {
 		tx.Exec("UPDATE routes_table SET status='published', last_seen=datetime('now'), miss_count=0 WHERE ip=?", ip)
 	}

--- a/backend/ospf_controller_service.go
+++ b/backend/ospf_controller_service.go
@@ -16,12 +16,12 @@ func ospfController() {
 		settings := getOspfControllerSettings()
 		coolingTime := time.Duration(settings.PushIntervalSeconds) * time.Second
 		var mode string
-		if err := db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil && err != sql.ErrNoRows {
+		if err := getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil && err != sql.ErrNoRows {
 			log.Printf("[WARN] SELECT value FROM settings WHERE key='mode' err: %v", err)
 		}
 		if mode != "C" && mode != "B" {
 			if !modeDemotedForNonBC {
-				if _, err := db.Exec("UPDATE routes_table SET status='candidate' WHERE status='published'"); err != nil {
+				if _, err := getDB().Exec("UPDATE routes_table SET status='candidate' WHERE status='published'"); err != nil {
 					log.Printf("[WARN] demote published routes to candidate failed: %v", err)
 				}
 				modeDemotedForNonBC = true
@@ -39,10 +39,10 @@ func ospfController() {
 		}
 		updated := false
 
-		db.Exec("UPDATE routes_table SET miss_count = miss_count + 1 WHERE status='published' AND datetime(last_seen, '+' || ttl || ' seconds') < datetime('now')")
+		getDB().Exec("UPDATE routes_table SET miss_count = miss_count + 1 WHERE status='published' AND datetime(last_seen, '+' || ttl || ' seconds') < datetime('now')")
 
 		var toDel []string
-		rowsDel, err := db.Query("SELECT ip FROM routes_table WHERE status='published' AND miss_count >= 3 LIMIT ?", settings.PushBatchLimit)
+		rowsDel, err := getDB().Query("SELECT ip FROM routes_table WHERE status='published' AND miss_count >= 3 LIMIT ?", settings.PushBatchLimit)
 		if err == nil {
 			for rowsDel.Next() {
 				var ip string
@@ -64,7 +64,7 @@ func ospfController() {
 		}
 
 		var toAdd []string
-		rowsAdd, err := db.Query("SELECT ip FROM routes_table WHERE status='candidate' AND first_seen <= datetime('now', '-60 seconds') LIMIT ?", settings.PushBatchLimit)
+		rowsAdd, err := getDB().Query("SELECT ip FROM routes_table WHERE status='candidate' AND first_seen <= datetime('now', '-60 seconds') LIMIT ?", settings.PushBatchLimit)
 		if err == nil {
 			for rowsAdd.Next() {
 				var ip string

--- a/backend/ospf_dns_cache.go
+++ b/backend/ospf_dns_cache.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	
 
 	"context"
 	"database/sql"
@@ -202,7 +201,7 @@ func lookupIPv4WithDNSServer(domain string, server string, _ bool) ([]string, er
 		return nil, fmt.Errorf("dig execution failed: %w", err)
 	}
 
-		lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
 	var ips []string
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -224,7 +223,7 @@ var resolveDomainIPv4WithTTLViaServers = func(domain string, dnsServers []string
 	}
 	var firstErr error
 	for _, server := range dnsServers {
-		// No more OS 'host' command for OSPF expansion. 
+		// No more OS 'host' command for OSPF expansion.
 		// We trust our resolver to query 127.0.0.1 (Mosdns).
 		ips, lookupErr := lookupIPv4WithDNSServer(domain, server, isRemote)
 		if lookupErr == nil {
@@ -251,7 +250,7 @@ var resolveDomainIPv4WithTTL = func(domain string) ([]string, int, error) {
 }
 
 func ensureRouteCacheTables() {
-	if db == nil {
+	if getDB() == nil {
 		return
 	}
 
@@ -284,7 +283,7 @@ func ensureRouteCacheTables() {
 		);`,
 	}
 	for _, stmt := range stmts {
-		if _, err := db.Exec(stmt); err != nil {
+		if _, err := getDB().Exec(stmt); err != nil {
 			log.Printf("[WARN] ensure route cache table failed: %v", err)
 		}
 	}
@@ -293,10 +292,10 @@ func ensureRouteCacheTables() {
 }
 
 func migrateLegacyDomainResolveCacheKeys() {
-	if db == nil {
+	if getDB() == nil {
 		return
 	}
-	result, err := db.Exec(`
+	result, err := getDB().Exec(`
 		INSERT OR IGNORE INTO domain_resolve_cache (domain, ips_json, dns_ttl, resolved_at, expire_at, last_error, fail_count, geodata_ver)
 		SELECT 'remote:' || domain, ips_json, dns_ttl, resolved_at, expire_at, last_error, fail_count, geodata_ver
 		FROM domain_resolve_cache
@@ -312,13 +311,13 @@ func migrateLegacyDomainResolveCacheKeys() {
 }
 
 func sweepLegacyDomainResolveCacheKeys(limit int) (migrated int64, removed int64, err error) {
-	if db == nil {
+	if getDB() == nil {
 		return 0, 0, nil
 	}
 	if limit <= 0 {
 		limit = 200
 	}
-	rows, err := db.Query("SELECT domain FROM domain_resolve_cache WHERE instr(domain, ':')=0 LIMIT ?", limit)
+	rows, err := getDB().Query("SELECT domain FROM domain_resolve_cache WHERE instr(domain, ':')=0 LIMIT ?", limit)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -339,7 +338,7 @@ func sweepLegacyDomainResolveCacheKeys(limit int) (migrated int64, removed int64
 		return 0, 0, nil
 	}
 
-	tx, err := db.Begin()
+	tx, err := getDB().Begin()
 	if err != nil {
 		return 0, 0, err
 	}
@@ -493,7 +492,7 @@ func getOrRefreshGeositeDomainCache(tag string) ([]string, int, error) {
 	geodataVer := getGeoDataVersion()
 	var domainsJSON string
 	var skipped int
-	if err := db.QueryRow("SELECT domains_json, skipped_count FROM geosite_expand_cache WHERE tag=? AND geodata_ver=?", tag, geodataVer).Scan(&domainsJSON, &skipped); err == nil {
+	if err := getDB().QueryRow("SELECT domains_json, skipped_count FROM geosite_expand_cache WHERE tag=? AND geodata_ver=?", tag, geodataVer).Scan(&domainsJSON, &skipped); err == nil {
 		var domains []string
 		if err := json.Unmarshal([]byte(domainsJSON), &domains); err == nil {
 			return domains, skipped, nil
@@ -505,7 +504,7 @@ func getOrRefreshGeositeDomainCache(tag string) ([]string, int, error) {
 		return nil, 0, err
 	}
 	payload, _ := json.Marshal(domains)
-	if _, err := db.Exec("INSERT INTO geosite_expand_cache (tag, geodata_ver, domains_json, skipped_count, updated_at) VALUES (?, ?, ?, ?, datetime('now')) ON CONFLICT(tag, geodata_ver) DO UPDATE SET domains_json=excluded.domains_json, skipped_count=excluded.skipped_count, updated_at=datetime('now')", tag, geodataVer, string(payload), skipped); err != nil {
+	if _, err := getDB().Exec("INSERT INTO geosite_expand_cache (tag, geodata_ver, domains_json, skipped_count, updated_at) VALUES (?, ?, ?, ?, datetime('now')) ON CONFLICT(tag, geodata_ver) DO UPDATE SET domains_json=excluded.domains_json, skipped_count=excluded.skipped_count, updated_at=datetime('now')", tag, geodataVer, string(payload), skipped); err != nil {
 		log.Printf("[WARN] persist geosite cache %q failed: %v", tag, err)
 	}
 	return domains, skipped, nil
@@ -529,7 +528,7 @@ func getOrRefreshDomainCacheWithResolver(domain string, resolverGroup string) ([
 	var expireAtUnix, resolvedAtUnix int64
 	var dnsTTL, failCount int
 	cacheHit := false
-	if err := db.QueryRow("SELECT ips_json, dns_ttl, CAST(resolved_at AS INTEGER), CAST(expire_at AS INTEGER), last_error, fail_count FROM domain_resolve_cache WHERE domain=?", cacheKey).Scan(&cachedIPsJSON, &dnsTTL, &resolvedAtUnix, &expireAtUnix, &lastError, &failCount); err == nil {
+	if err := getDB().QueryRow("SELECT ips_json, dns_ttl, CAST(resolved_at AS INTEGER), CAST(expire_at AS INTEGER), last_error, fail_count FROM domain_resolve_cache WHERE domain=?", cacheKey).Scan(&cachedIPsJSON, &dnsTTL, &resolvedAtUnix, &expireAtUnix, &lastError, &failCount); err == nil {
 		cacheHit = true
 		var cachedIPs []string
 		_ = json.Unmarshal([]byte(cachedIPsJSON), &cachedIPs)
@@ -547,7 +546,7 @@ func getOrRefreshDomainCacheWithResolver(domain string, resolverGroup string) ([
 		payload, _ := json.Marshal(ips)
 		expireAt := now.Add(time.Duration(ttl) * time.Second).Unix()
 		resolvedAt := now.Unix()
-		if _, execErr := db.Exec("INSERT INTO domain_resolve_cache (domain, ips_json, dns_ttl, resolved_at, expire_at, last_error, fail_count, geodata_ver) VALUES (?, ?, ?, ?, ?, '', 0, ?) ON CONFLICT(domain) DO UPDATE SET ips_json=excluded.ips_json, dns_ttl=excluded.dns_ttl, resolved_at=excluded.resolved_at, expire_at=excluded.expire_at, last_error='', fail_count=0, geodata_ver=excluded.geodata_ver", cacheKey, string(payload), ttl, resolvedAt, expireAt, getGeoDataVersion()); execErr != nil {
+		if _, execErr := getDB().Exec("INSERT INTO domain_resolve_cache (domain, ips_json, dns_ttl, resolved_at, expire_at, last_error, fail_count, geodata_ver) VALUES (?, ?, ?, ?, ?, '', 0, ?) ON CONFLICT(domain) DO UPDATE SET ips_json=excluded.ips_json, dns_ttl=excluded.dns_ttl, resolved_at=excluded.resolved_at, expire_at=excluded.expire_at, last_error='', fail_count=0, geodata_ver=excluded.geodata_ver", cacheKey, string(payload), ttl, resolvedAt, expireAt, getGeoDataVersion()); execErr != nil {
 			log.Printf("[WARN] persist domain cache %q failed: %v", domain, execErr)
 		}
 		return ips, ttl, false, nil
@@ -564,7 +563,7 @@ func getOrRefreshDomainCacheWithResolver(domain string, resolverGroup string) ([
 			}
 			nextRetryTTL = clampDomainCacheTTL(nextRetryTTL)
 			nextRetryAt := now.Add(time.Duration(domainFailureRetrySeconds) * time.Second).Unix()
-			if _, execErr := db.Exec("UPDATE domain_resolve_cache SET expire_at=?, last_error=?, fail_count=fail_count+1 WHERE domain=?", nextRetryAt, err.Error(), cacheKey); execErr != nil {
+			if _, execErr := getDB().Exec("UPDATE domain_resolve_cache SET expire_at=?, last_error=?, fail_count=fail_count+1 WHERE domain=?", nextRetryAt, err.Error(), cacheKey); execErr != nil {
 				log.Printf("[WARN] update domain cache failure state %q failed: %v", domain, execErr)
 			}
 			return cachedIPs, nextRetryTTL, false, nil

--- a/backend/ospf_geoip_lock.go
+++ b/backend/ospf_geoip_lock.go
@@ -6,10 +6,10 @@ import (
 )
 
 func ensureDomainGeoIPLockTable() {
-	if db == nil {
+	if getDB() == nil {
 		return
 	}
-	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS domain_geoip_lock (
+	if _, err := getDB().Exec(`CREATE TABLE IF NOT EXISTS domain_geoip_lock (
 		domain TEXT NOT NULL,
 		resolver_group TEXT NOT NULL,
 		geoip_tag TEXT NOT NULL,
@@ -29,7 +29,7 @@ func loadDomainGeoIPLockedTags(domain, resolverGroup, geodataVer string) []strin
 	if domain == "" || geodataVer == "" {
 		return nil
 	}
-	rows, err := db.Query("SELECT geoip_tag FROM domain_geoip_lock WHERE domain=? AND resolver_group=? AND geodata_ver=?", domain, resolverGroup, geodataVer)
+	rows, err := getDB().Query("SELECT geoip_tag FROM domain_geoip_lock WHERE domain=? AND resolver_group=? AND geodata_ver=?", domain, resolverGroup, geodataVer)
 	if err != nil {
 		return nil
 	}
@@ -53,7 +53,7 @@ func loadDomainGeoIPLockedTags(domain, resolverGroup, geodataVer string) []strin
 		set[routeKey] = struct{}{}
 	}
 	for _, bad := range invalid {
-		_, _ = db.Exec("DELETE FROM domain_geoip_lock WHERE domain=? AND resolver_group=? AND geodata_ver=? AND geoip_tag=?", domain, resolverGroup, geodataVer, bad)
+		_, _ = getDB().Exec("DELETE FROM domain_geoip_lock WHERE domain=? AND resolver_group=? AND geodata_ver=? AND geoip_tag=?", domain, resolverGroup, geodataVer, bad)
 	}
 	if len(set) == 0 {
 		return nil
@@ -93,7 +93,7 @@ func saveDomainGeoIPLockTags(domain, resolverGroup, geodataVer string, tags []st
 		normalized = append(normalized, routeKey)
 	}
 
-	tx, err := db.Begin()
+	tx, err := getDB().Begin()
 	if err != nil {
 		return
 	}

--- a/backend/ospf_publish_policy.go
+++ b/backend/ospf_publish_policy.go
@@ -8,7 +8,7 @@ import (
 
 func loadOspfPublishAllowlist() []*net.IPNet {
 	var raw string
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='ospf_publish_allowlist'").Scan(&raw); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='ospf_publish_allowlist'").Scan(&raw); err != nil {
 		return nil
 	}
 	raw = strings.TrimSpace(raw)

--- a/backend/ospf_reconcile_service.go
+++ b/backend/ospf_reconcile_service.go
@@ -14,14 +14,14 @@ func reconcilePublishedRoutesWithFRR() {
 		log.Printf("[WARN] OSPF reconcile skip: %v", err)
 		return
 	}
-	rows, err := db.Query("SELECT ip, status FROM routes_table WHERE source='static'")
+	rows, err := getDB().Query("SELECT ip, status FROM routes_table WHERE source='static'")
 	if err != nil {
 		log.Printf("[WARN] OSPF reconcile query failed: %v", err)
 		return
 	}
 	defer rows.Close()
 
-	tx, err := db.Begin()
+	tx, err := getDB().Begin()
 	if err != nil {
 		log.Printf("[WARN] OSPF reconcile begin failed: %v", err)
 		return
@@ -69,7 +69,7 @@ func reconcilePublishedRoutesWithFRR() {
 	}
 
 	var mode string
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil || strings.TrimSpace(mode) == "" {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil || strings.TrimSpace(mode) == "" {
 		mode = "A"
 	}
 	mode = strings.TrimSpace(mode)

--- a/backend/ospf_route_state_service.go
+++ b/backend/ospf_route_state_service.go
@@ -638,7 +638,7 @@ func detectModeSwitchProtectedConflicts(mode string) []string {
 		}
 	}
 
-	rows, err := db.Query("SELECT ip FROM routes_table WHERE status IN ('candidate','published') AND source='static'")
+	rows, err := getDB().Query("SELECT ip FROM routes_table WHERE status IN ('candidate','published') AND source='static'")
 	if err == nil {
 		defer rows.Close()
 		for rows.Next() {
@@ -649,7 +649,7 @@ func detectModeSwitchProtectedConflicts(mode string) []string {
 		}
 	}
 
-	staticRows, err := db.Query("SELECT value FROM rules WHERE type='ip' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
+	staticRows, err := getDB().Query("SELECT value FROM rules WHERE type='ip' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
 	if err == nil {
 		defer staticRows.Close()
 		for staticRows.Next() {
@@ -661,7 +661,7 @@ func detectModeSwitchProtectedConflicts(mode string) []string {
 	}
 
 	geoipPath := getPath("core", "mosdns", "geoip.dat")
-	geoipRows, err := db.Query("SELECT value FROM rules WHERE type='geoip' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
+	geoipRows, err := getDB().Query("SELECT value FROM rules WHERE type='geoip' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
 	if err == nil {
 		defer geoipRows.Close()
 		for geoipRows.Next() {
@@ -682,7 +682,7 @@ func detectModeSwitchProtectedConflicts(mode string) []string {
 		}
 	}
 
-	domainRows, err := db.Query("SELECT value, policy FROM rules WHERE type='domain' AND (policy LIKE 'proxy%' OR policy LIKE 'direct%' OR policy LIKE 'ha-%')")
+	domainRows, err := getDB().Query("SELECT value, policy FROM rules WHERE type='domain' AND (policy LIKE 'proxy%' OR policy LIKE 'direct%' OR policy LIKE 'ha-%')")
 	if err == nil {
 		defer domainRows.Close()
 		for domainRows.Next() {

--- a/backend/ospf_route_state_service.go
+++ b/backend/ospf_route_state_service.go
@@ -103,6 +103,7 @@ func extractHostForProtection(raw string) string {
 }
 
 func collectProtectedRouteKeys() map[string]struct{} {
+	d := getDB()
 	protected := make(map[string]struct{})
 	hosts := make(map[string]struct{})
 
@@ -115,7 +116,10 @@ func collectProtectedRouteKeys() map[string]struct{} {
 	}
 
 	collectColumn := func(query string) {
-		rows, err := db.Query(query)
+		if d == nil {
+			return
+		}
+		rows, err := d.Query(query)
 		if err != nil {
 			log.Printf("[OSPF] collect protected hosts query failed: %v", err)
 			return
@@ -159,6 +163,10 @@ func collectProtectedRouteKeys() map[string]struct{} {
 
 func collectStaticRoutesForMode(mode string, protected map[string]struct{}) (map[string]routeState, []string) {
 	ensureRouteCacheTables()
+	d := getDB()
+	if d == nil {
+		return map[string]routeState{}, nil
+	}
 	staticRoutes := make(map[string]routeState)
 	conflictSet := make(map[string]struct{})
 	geoipPath := getPath("core", "mosdns", "geoip.dat")
@@ -305,7 +313,7 @@ func collectStaticRoutesForMode(mode string, protected map[string]struct{}) (map
 		return keptStr
 	}
 
-	staticRows, err := db.Query("SELECT value FROM rules WHERE type='ip' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
+	staticRows, err := d.Query("SELECT value FROM rules WHERE type='ip' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
 	if err == nil {
 		for staticRows.Next() {
 			var ip string
@@ -316,7 +324,7 @@ func collectStaticRoutesForMode(mode string, protected map[string]struct{}) (map
 		staticRows.Close()
 	}
 
-	geoipRows, err := db.Query("SELECT value FROM rules WHERE type='geoip' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
+	geoipRows, err := d.Query("SELECT value FROM rules WHERE type='geoip' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
 	if err == nil {
 		for geoipRows.Next() {
 			var tag string
@@ -338,7 +346,7 @@ func collectStaticRoutesForMode(mode string, protected map[string]struct{}) (map
 	}
 
 	if mode == "C" {
-		geositeRows, err := db.Query("SELECT value, policy FROM rules WHERE type='geosite' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
+		geositeRows, err := d.Query("SELECT value, policy FROM rules WHERE type='geosite' AND (policy LIKE 'proxy%' OR policy LIKE 'ha-%')")
 		if err != nil {
 			log.Printf("[OSPF] geosite rule query failed: %v", err)
 		} else {
@@ -488,7 +496,7 @@ func collectStaticRoutesForMode(mode string, protected map[string]struct{}) (map
 			}
 		}
 
-		domainRows, err := db.Query("SELECT value, policy FROM rules WHERE type='domain' AND (policy LIKE 'proxy%' OR policy LIKE 'direct%' OR policy LIKE 'ha-%')")
+		domainRows, err := d.Query("SELECT value, policy FROM rules WHERE type='domain' AND (policy LIKE 'proxy%' OR policy LIKE 'direct%' OR policy LIKE 'ha-%')")
 		if err == nil {
 			type domainRule struct {
 				domain string

--- a/backend/ospf_sync_service.go
+++ b/backend/ospf_sync_service.go
@@ -8,8 +8,8 @@ import (
 
 func syncFRRConfig() {
 	var mode string
-	if db != nil {
-		db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
+	if getDB() != nil {
+		getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
 	}
 
 	if mode == "A" || mode == "" {
@@ -65,7 +65,7 @@ route-map OSPF-EXPORT permit 10
 	_ = sysCmd.run("systemctl", "enable", "frr")
 	if configChanged {
 		sysCmd.run("systemctl", "restart", "frr")
-		db.Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
+		getDB().Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
 	} else if sysCmd.run("systemctl", "is-active", "--quiet", "frr") != nil {
 		log.Printf("[OSPF] FRR config unchanged but service inactive; starting frr for mode=%s", mode)
 		sysCmd.run("systemctl", "start", "frr")
@@ -84,6 +84,8 @@ func scheduleStaticRouteSync(mode string) {
 	}
 	staticRouteSyncRunning = true
 	staticRouteSyncMu.Unlock()
+
+	syncFn := syncStaticRoutesToOSPFFunc
 
 	go func() {
 		defer func() {
@@ -104,7 +106,7 @@ func scheduleStaticRouteSync(mode string) {
 				}
 			}
 			if currentMode == "B" || currentMode == "C" {
-				syncStaticRoutesToOSPFFunc(currentMode)
+				syncFn(currentMode)
 			}
 
 			staticRouteSyncMu.Lock()

--- a/backend/ospf_sync_service.go
+++ b/backend/ospf_sync_service.go
@@ -97,9 +97,9 @@ func scheduleStaticRouteSync(mode string) {
 			staticRouteSyncMu.Unlock()
 
 			currentMode := mode
-			if db != nil {
+			if d := getDB(); d != nil {
 				var dbMode string
-				if err := db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&dbMode); err == nil && dbMode != "" {
+				if err := d.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&dbMode); err == nil && dbMode != "" {
 					currentMode = dbMode
 				}
 			}
@@ -119,6 +119,10 @@ func scheduleStaticRouteSync(mode string) {
 }
 
 func syncStaticRoutesToOSPF(mode string) {
+	d := getDB()
+	if d == nil {
+		return
+	}
 	protected := collectProtectedRouteKeys()
 	staticRoutes, conflicts := collectStaticRoutesForMode(mode, protected)
 	staticRoutes, pruned := pruneStaticRoutesPreferBroad(staticRoutes)
@@ -130,7 +134,7 @@ func syncStaticRoutesToOSPF(mode string) {
 	}
 
 	var toDelete []string
-	oldRows, err := db.Query("SELECT ip FROM routes_table WHERE source='static'")
+	oldRows, err := d.Query("SELECT ip FROM routes_table WHERE source='static'")
 	if err == nil {
 		for oldRows.Next() {
 			var ip string
@@ -143,7 +147,7 @@ func syncStaticRoutesToOSPF(mode string) {
 		oldRows.Close()
 	}
 
-	txSync, err := db.Begin()
+	txSync, err := d.Begin()
 	if err != nil {
 		log.Printf("[WARN] syncStaticRoutesToOSPF begin tx failed: %v", err)
 		return

--- a/backend/protected_ip_repository.go
+++ b/backend/protected_ip_repository.go
@@ -12,7 +12,7 @@ type ProtectedIPItem struct {
 func NewProtectedIPRepository() *ProtectedIPRepository { return &ProtectedIPRepository{} }
 
 func (r *ProtectedIPRepository) List() ([]ProtectedIPItem, error) {
-	rows, err := db.Query("SELECT id, value, remark, created_at FROM protected_ips ORDER BY id DESC")
+	rows, err := getDB().Query("SELECT id, value, remark, created_at FROM protected_ips ORDER BY id DESC")
 	if err != nil {
 		return nil, err
 	}
@@ -29,11 +29,11 @@ func (r *ProtectedIPRepository) List() ([]ProtectedIPItem, error) {
 }
 
 func (r *ProtectedIPRepository) Create(value, remark string) error {
-	_, err := db.Exec("INSERT INTO protected_ips (value, remark) VALUES (?, ?)", value, remark)
+	_, err := getDB().Exec("INSERT INTO protected_ips (value, remark) VALUES (?, ?)", value, remark)
 	return err
 }
 
 func (r *ProtectedIPRepository) Delete(id string) error {
-	_, err := db.Exec("DELETE FROM protected_ips WHERE id=?", id)
+	_, err := getDB().Exec("DELETE FROM protected_ips WHERE id=?", id)
 	return err
 }

--- a/backend/remote_node_mock_test.go
+++ b/backend/remote_node_mock_test.go
@@ -53,17 +53,17 @@ func TestCreateAndDeployRemoteNode_StoresNodeAndStartsAsyncDeploy(t *testing.T) 
 func TestCheckRemoteNode_UsesMockSSHConnector(t *testing.T) {
 	r := setupFeatureSuiteRouter(t)
 
-	oldConnect := remoteConnect
-	defer func() { remoteConnect = oldConnect }()
+	oldConnect := getRemoteConnect()
+	defer func() { setRemoteConnect(oldConnect) }()
 
-	remoteConnect = func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
+	setRemoteConnect(func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
 		return &fakeSSHClient{run: func(cmd string) (string, string, error) {
 			if cmd != "systemctl is-active xray" {
 				t.Fatalf("unexpected command: %s", cmd)
 			}
 			return "active\n", "", nil
 		}}, nil
-	}
+	})
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, authedRequest(http.MethodPost, "/api/remote_nodes/2/check"))
@@ -134,12 +134,12 @@ func TestRollbackRemoteNode_LoadsHistoryAndStartsMockDeploy(t *testing.T) {
 func TestCheckRemoteNode_OfflineWhenConnectorFails(t *testing.T) {
 	r := setupFeatureSuiteRouter(t)
 
-	oldConnect := remoteConnect
-	defer func() { remoteConnect = oldConnect }()
+	oldConnect := getRemoteConnect()
+	defer func() { setRemoteConnect(oldConnect) }()
 
-	remoteConnect = func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
+	setRemoteConnect(func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
 		return nil, errors.New("boom")
-	}
+	})
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, authedRequest(http.MethodPost, "/api/remote_nodes/2/check"))
@@ -154,14 +154,14 @@ func TestCheckRemoteNode_OfflineWhenConnectorFails(t *testing.T) {
 func TestDoDeployRoutine_LogsRemoteStdoutAndStderrOnFailure(t *testing.T) {
 	setupFeatureSuiteRouter(t)
 
-	oldConnect := remoteConnect
-	defer func() { remoteConnect = oldConnect }()
+	oldConnect := getRemoteConnect()
+	defer func() { setRemoteConnect(oldConnect) }()
 
-	remoteConnect = func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
+	setRemoteConnect(func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
 		return &fakeSSHClient{run: func(cmd string) (string, string, error) {
 			return "apt stdout", "apt stderr", fmt.Errorf("Process exited with status 100")
 		}}, nil
-	}
+	})
 
 	req := RemoteNodeReq{
 		Name:          "192.168.20.152",
@@ -200,18 +200,18 @@ func TestDoDeployRoutine_LogsRemoteStdoutAndStderrOnFailure(t *testing.T) {
 func TestDoDeployRoutine_RefusesToAutoTrustRotatedFingerprint(t *testing.T) {
 	setupFeatureSuiteRouter(t)
 
-	oldConnect := remoteConnect
-	defer func() { remoteConnect = oldConnect }()
+	oldConnect := getRemoteConnect()
+	defer func() { setRemoteConnect(oldConnect) }()
 
 	newFP := "SHA256:wo1Wuz3UhufbAdlhwnCKYyvQlYmcLeLBQVq3tkq1PRo"
 	calls := 0
-	remoteConnect = func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
+	setRemoteConnect(func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
 		calls++
 		if expectedHostKey != "SHA256:test" {
 			t.Fatalf("expected pinned key, got %s", expectedHostKey)
 		}
 		return nil, fmt.Errorf("failed to dial: ssh: handshake failed: Strict Host Key checking failed. The server's fingerprint is %s. Please update", newFP)
-	}
+	})
 
 	req := RemoteNodeReq{
 		Name:          "192.168.20.152",

--- a/backend/remote_nodes_controller.go
+++ b/backend/remote_nodes_controller.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strings"
+	"sync"
 )
 
 type RemoteNodeReq struct {
@@ -33,6 +34,20 @@ type remoteSSHClient interface {
 
 var remoteConnect = func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
 	return remote_deploy.Connect(host, port, user, authType, credential, expectedHostKey)
+}
+
+var remoteConnectMu sync.RWMutex
+
+func getRemoteConnect() func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
+	remoteConnectMu.RLock()
+	defer remoteConnectMu.RUnlock()
+	return remoteConnect
+}
+
+func setRemoteConnect(fn func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error)) {
+	remoteConnectMu.Lock()
+	remoteConnect = fn
+	remoteConnectMu.Unlock()
 }
 
 var startDeployRoutine = func(id int64, req RemoteNodeReq, isUpdate bool, params map[string]interface{}) {
@@ -199,7 +214,7 @@ func extractFingerprintFromSSHError(err error) string {
 }
 
 func connectWithAutoHostKey(id int64, req *RemoteNodeReq) (remoteSSHClient, error) {
-	sshClient, err := remoteConnect(req.SSHHost, req.SSHPort, req.SSHUser, req.SSHAuthType, req.SSHCredential, req.SSHHostKey)
+	sshClient, err := getRemoteConnect()(req.SSHHost, req.SSHPort, req.SSHUser, req.SSHAuthType, req.SSHCredential, req.SSHHostKey)
 	if err == nil {
 		return sshClient, nil
 	}
@@ -233,7 +248,7 @@ func connectWithAutoHostKey(id int64, req *RemoteNodeReq) (remoteSSHClient, erro
 	logAction(id, "deploy", "running", fmt.Sprintf("Pinned initial SSH host fingerprint to %s and retrying deployment", fp))
 	req.SSHHostKey = fp
 
-	sshClient, err = remoteConnect(req.SSHHost, req.SSHPort, req.SSHUser, req.SSHAuthType, req.SSHCredential, req.SSHHostKey)
+	sshClient, err = getRemoteConnect()(req.SSHHost, req.SSHPort, req.SSHUser, req.SSHAuthType, req.SSHCredential, req.SSHHostKey)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +434,7 @@ func deleteRemoteNode(c *gin.Context) {
 	req, err := fetchNodeReq(id)
 	if err == nil {
 		goSafe(func() {
-			client, err := remoteConnect(req.SSHHost, req.SSHPort, req.SSHUser, req.SSHAuthType, req.SSHCredential, req.SSHHostKey)
+			client, err := getRemoteConnect()(req.SSHHost, req.SSHPort, req.SSHUser, req.SSHAuthType, req.SSHCredential, req.SSHHostKey)
 			if err == nil {
 				defer client.Close()
 				if req.Type == "wg" {
@@ -447,7 +462,7 @@ func checkRemoteNode(c *gin.Context) {
 		return
 	}
 
-	client, err := remoteConnect(info.Host, info.Port, info.User, info.AuthType, info.Credential, info.HostKey)
+	client, err := getRemoteConnect()(info.Host, info.Port, info.User, info.AuthType, info.Credential, info.HostKey)
 	if err != nil {
 		NewRemoteNodesRepository().SetRemoteNodeStatus(id, "Offline")
 		logAction(0, "check", "failed", fmt.Sprintf("Node %s SSH check failed: %v", id, err))

--- a/backend/remote_nodes_repository.go
+++ b/backend/remote_nodes_repository.go
@@ -49,7 +49,7 @@ type RemoteNodesRepository struct {
 }
 
 func NewRemoteNodesRepository() *RemoteNodesRepository {
-	return &RemoteNodesRepository{db: db}
+	return &RemoteNodesRepository{db: getDB()}
 }
 
 func (r *RemoteNodesRepository) ListRemoteNodes() ([]map[string]interface{}, error) {

--- a/backend/rules_repository.go
+++ b/backend/rules_repository.go
@@ -10,7 +10,7 @@ type RulesRepository struct {
 }
 
 func NewRulesRepository() *RulesRepository {
-	return &RulesRepository{db: db}
+	return &RulesRepository{db: getDB()}
 }
 
 func (r *RulesRepository) CollectRuleGroups() []map[string]interface{} {

--- a/backend/system_repository.go
+++ b/backend/system_repository.go
@@ -18,57 +18,57 @@ type SystemRepository struct{}
 func NewSystemRepository() *SystemRepository { return &SystemRepository{} }
 
 func (r *SystemRepository) SaveNetworkRoleSettings(managementIface, serviceIface string) error {
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('management_iface', ?)", managementIface); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('management_iface', ?)", managementIface); err != nil {
 		return err
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('service_iface', ?)", serviceIface); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('service_iface', ?)", serviceIface); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (r *SystemRepository) SaveMode(mode string) error {
-	_, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('mode', ?)", mode)
+	_, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('mode', ?)", mode)
 	return err
 }
 
 func (r *SystemRepository) SaveCronDefaults(cronTime, scheduleType string, weekday, monthday int) {
-	_, _ = db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_time', ?)", cronTime)
-	_, _ = db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_schedule_type', ?)", scheduleType)
-	_, _ = db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_weekday', ?)", strconv.Itoa(weekday))
-	_, _ = db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_monthday', ?)", strconv.Itoa(monthday))
+	_, _ = getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_time', ?)", cronTime)
+	_, _ = getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_schedule_type', ?)", scheduleType)
+	_, _ = getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_weekday', ?)", strconv.Itoa(weekday))
+	_, _ = getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_monthday', ?)", strconv.Itoa(monthday))
 }
 
 func (r *SystemRepository) SaveCronSettings(enabled bool, cronTime, scheduleType string, weekday, monthday int) error {
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_enabled', ?)", fmt.Sprintf("%t", enabled)); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_enabled', ?)", fmt.Sprintf("%t", enabled)); err != nil {
 		return err
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_time', ?)", cronTime); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_time', ?)", cronTime); err != nil {
 		return err
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_schedule_type', ?)", scheduleType); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_schedule_type', ?)", scheduleType); err != nil {
 		return err
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_weekday', ?)", strconv.Itoa(weekday)); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_weekday', ?)", strconv.Itoa(weekday)); err != nil {
 		return err
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_monthday', ?)", strconv.Itoa(monthday)); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('cron_monthday', ?)", strconv.Itoa(monthday)); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (r *SystemRepository) SaveOspfSettings(batchLimit, intervalSeconds, resolveWorkers int, allowlist string) error {
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('ospf_push_batch_limit', ?)", strconv.Itoa(batchLimit)); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('ospf_push_batch_limit', ?)", strconv.Itoa(batchLimit)); err != nil {
 		return err
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('ospf_push_interval_seconds', ?)", strconv.Itoa(intervalSeconds)); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('ospf_push_interval_seconds', ?)", strconv.Itoa(intervalSeconds)); err != nil {
 		return err
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('ospf_resolve_workers', ?)", strconv.Itoa(resolveWorkers)); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('ospf_resolve_workers', ?)", strconv.Itoa(resolveWorkers)); err != nil {
 		return err
 	}
-	if _, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('ospf_publish_allowlist', ?)", allowlist); err != nil {
+	if _, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('ospf_publish_allowlist', ?)", allowlist); err != nil {
 		return err
 	}
 	return nil
@@ -76,13 +76,13 @@ func (r *SystemRepository) SaveOspfSettings(batchLimit, intervalSeconds, resolve
 
 func (r *SystemRepository) GetMode() (string, error) {
 	var mode string
-	err := db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
+	err := getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
 	return mode, err
 }
 
 func (r *SystemRepository) GetMonthlyTrafficTotal() (int64, int64, error) {
 	var totalMonthUp, totalMonthDown int64
-	err := db.QueryRow(`
+	err := getDB().QueryRow(`
 		SELECT COALESCE(SUM(up_bytes), 0), COALESCE(SUM(down_bytes), 0)
 		FROM traffic_history
 		WHERE ts >= date('now', 'start of month')
@@ -91,7 +91,7 @@ func (r *SystemRepository) GetMonthlyTrafficTotal() (int64, int64, error) {
 }
 
 func (r *SystemRepository) GetMonthlyNodeTrafficRanking(limit int) ([]NodeTrafficRanking, error) {
-	rows, err := db.Query(`
+	rows, err := getDB().Query(`
 		SELECT n.id,
 		       n.name,
 		       COALESCE(SUM(h.up_bytes), 0)   AS up_bytes,
@@ -126,10 +126,10 @@ func (r *SystemRepository) GetMonthlyNodeTrafficRanking(limit int) ([]NodeTraffi
 }
 
 func (r *SystemRepository) GetOspfRouteCounts() (published int, candidate int, err error) {
-	if err = db.QueryRow("SELECT count(*) FROM routes_table WHERE status='published'").Scan(&published); err != nil {
+	if err = getDB().QueryRow("SELECT count(*) FROM routes_table WHERE status='published'").Scan(&published); err != nil {
 		return 0, 0, err
 	}
-	if err = db.QueryRow("SELECT count(*) FROM routes_table WHERE status='candidate'").Scan(&candidate); err != nil {
+	if err = getDB().QueryRow("SELECT count(*) FROM routes_table WHERE status='candidate'").Scan(&candidate); err != nil {
 		return 0, 0, err
 	}
 	return published, candidate, nil
@@ -137,12 +137,12 @@ func (r *SystemRepository) GetOspfRouteCounts() (published int, candidate int, e
 
 func (r *SystemRepository) GetOspfPublishAllowlist() (string, error) {
 	var allowlist string
-	err := db.QueryRow("SELECT value FROM settings WHERE key='ospf_publish_allowlist'").Scan(&allowlist)
+	err := getDB().QueryRow("SELECT value FROM settings WHERE key='ospf_publish_allowlist'").Scan(&allowlist)
 	return allowlist, err
 }
 
 func (r *SystemRepository) ResetOspfPendingStaticRoutes() (int64, error) {
-	res, err := db.Exec("DELETE FROM routes_table WHERE status='candidate' AND source='static'")
+	res, err := getDB().Exec("DELETE FROM routes_table WHERE status='candidate' AND source='static'")
 	if err != nil {
 		return 0, err
 	}

--- a/backend/system_service.go
+++ b/backend/system_service.go
@@ -52,20 +52,20 @@ var modeSwitchFinalizeRoutes = func(mode string) error {
 	if mode == "C" {
 		return nil
 	}
-	_, err := db.Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
+	_, err := getDB().Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
 	return err
 }
 
 func currentMode() string {
 	var mode string
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil || strings.TrimSpace(mode) == "" {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil || strings.TrimSpace(mode) == "" {
 		return "A"
 	}
 	return strings.TrimSpace(mode)
 }
 
 func setModeValue(mode string) error {
-	_, err := db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('mode', ?)", mode)
+	_, err := getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('mode', ?)", mode)
 	return err
 }
 
@@ -317,8 +317,8 @@ func findNetworkByIface(options []networkInterfaceInfo, ifaceName string) (netwo
 
 func loadNetworkRoleSettings() (string, string) {
 	var managementIface, serviceIface string
-	_ = db.QueryRow("SELECT value FROM settings WHERE key='management_iface'").Scan(&managementIface)
-	_ = db.QueryRow("SELECT value FROM settings WHERE key='service_iface'").Scan(&serviceIface)
+	_ = getDB().QueryRow("SELECT value FROM settings WHERE key='management_iface'").Scan(&managementIface)
+	_ = getDB().QueryRow("SELECT value FROM settings WHERE key='service_iface'").Scan(&serviceIface)
 	managementIface = strings.TrimSpace(managementIface)
 	serviceIface = strings.TrimSpace(serviceIface)
 	return managementIface, serviceIface
@@ -336,8 +336,8 @@ func ensureDefaultNetworkRoleSettings() {
 	if serviceIface == "" {
 		serviceIface = managementIface
 	}
-	_, _ = db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('management_iface', ?)", managementIface)
-	_, _ = db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('service_iface', ?)", serviceIface)
+	_, _ = getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('management_iface', ?)", managementIface)
+	_, _ = getDB().Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('service_iface', ?)", serviceIface)
 }
 
 func getBuildInfo() (string, string) {

--- a/backend/test_controller.go
+++ b/backend/test_controller.go
@@ -34,7 +34,7 @@ func (ctl *TestController) HandleHealthCheck(c *gin.Context) {
 	// 1. DB Check
 	dbStatus := "OK"
 	dbDetails := ""
-	if err := db.Ping(); err != nil {
+	if err := getDB().Ping(); err != nil {
 		dbStatus = "Error"
 		dbDetails = err.Error()
 	}
@@ -89,7 +89,7 @@ func (ctl *TestController) HandleHealthCheck(c *gin.Context) {
 
 	// 5. Mode-specific check
 	var mode string
-	_ = db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
+	_ = getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
 	if mode == "A" {
 		res := sysCmd.runCombinedOutput("nft", "list", "ruleset")
 		if res.Err != nil {
@@ -132,7 +132,7 @@ func (ctl *TestController) HandleTrace(c *gin.Context) {
 
 	active, defaultID := getActiveNodeContext()
 	var failoverMode string
-	_ = db.QueryRow("SELECT value FROM settings WHERE key='node_failover_mode'").Scan(&failoverMode)
+	_ = getDB().QueryRow("SELECT value FROM settings WHERE key='node_failover_mode'").Scan(&failoverMode)
 	strictFailover := normalizeNodeFailoverMode(strings.TrimSpace(strings.ToLower(failoverMode))) == "strict"
 
 	ip := net.ParseIP(target)
@@ -142,7 +142,7 @@ func (ctl *TestController) HandleTrace(c *gin.Context) {
 		targetType = "ip"
 	}
 
-	rows, err := db.Query("SELECT id, type, value, policy FROM rules ORDER BY priority ASC, id ASC")
+	rows, err := getDB().Query("SELECT id, type, value, policy FROM rules ORDER BY priority ASC, id ASC")
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
 		return
@@ -192,7 +192,7 @@ func (ctl *TestController) HandleTrace(c *gin.Context) {
 					targetTag := strings.ToLower(strings.TrimSpace(rvalue))
 					isExclude := strings.HasPrefix(targetTag, "!")
 					pureTag := strings.TrimPrefix(targetTag, "!")
-					
+
 					tagFound := false
 					for _, t := range tags {
 						if t == pureTag {
@@ -246,10 +246,10 @@ func (ctl *TestController) HandleTrace(c *gin.Context) {
 	if result == nil {
 		// Default fallback
 		var defaultPolicy string
-		if err := db.QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil {
+		if err := getDB().QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil {
 			defaultPolicy = "proxy"
 		}
-		
+
 		outbound := "direct"
 		if strings.ToLower(defaultPolicy) == "proxy" {
 			if defaultID > 0 {

--- a/backend/traffic_stats.go
+++ b/backend/traffic_stats.go
@@ -31,7 +31,7 @@ var (
 )
 
 func initTrafficDB() {
-	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS traffic_history (
+	if _, err := getDB().Exec(`CREATE TABLE IF NOT EXISTS traffic_history (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		ts DATETIME DEFAULT CURRENT_TIMESTAMP,
 		up_bytes INTEGER,
@@ -39,10 +39,10 @@ func initTrafficDB() {
 	)`); err != nil {
 		log.Printf("[WARN] Failed to create traffic_history table: %v", err)
 	}
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_traffic_history_ts ON traffic_history(ts)`); err != nil {
+	if _, err := getDB().Exec(`CREATE INDEX IF NOT EXISTS idx_traffic_history_ts ON traffic_history(ts)`); err != nil {
 		log.Printf("[WARN] Failed to create index on traffic_history: %v", err)
 	}
-	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS node_traffic_history (
+	if _, err := getDB().Exec(`CREATE TABLE IF NOT EXISTS node_traffic_history (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		ts DATETIME DEFAULT CURRENT_TIMESTAMP,
 		node_id INTEGER NOT NULL,
@@ -51,13 +51,13 @@ func initTrafficDB() {
 	)`); err != nil {
 		log.Printf("[WARN] Failed to create node_traffic_history table: %v", err)
 	}
-	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_node_traffic_history_ts ON node_traffic_history(ts)`); err != nil {
+	if _, err := getDB().Exec(`CREATE INDEX IF NOT EXISTS idx_node_traffic_history_ts ON node_traffic_history(ts)`); err != nil {
 		log.Printf("[WARN] Failed to create index on node_traffic_history: %v", err)
 	}
-	if _, err := db.Exec(`DELETE FROM traffic_history WHERE ts < datetime('now', '-180 days')`); err != nil {
+	if _, err := getDB().Exec(`DELETE FROM traffic_history WHERE ts < datetime('now', '-180 days')`); err != nil {
 		log.Printf("[WARN] prune traffic_history failed: %v", err)
 	}
-	if _, err := db.Exec(`DELETE FROM node_traffic_history WHERE ts < datetime('now', '-180 days')`); err != nil {
+	if _, err := getDB().Exec(`DELETE FROM node_traffic_history WHERE ts < datetime('now', '-180 days')`); err != nil {
 		log.Printf("[WARN] prune node_traffic_history failed: %v", err)
 	}
 }
@@ -171,7 +171,7 @@ func startTrafficMonitor() {
 			trafficMutex.Unlock()
 
 			if saveUp > 0 || saveDown > 0 {
-				if _, err := db.Exec(`INSERT INTO traffic_history (up_bytes, down_bytes) VALUES (?, ?)`, saveUp, saveDown); err != nil {
+				if _, err := getDB().Exec(`INSERT INTO traffic_history (up_bytes, down_bytes) VALUES (?, ?)`, saveUp, saveDown); err != nil {
 					log.Printf("[WARN] insert traffic_history failed: %v", err)
 				}
 			}
@@ -179,14 +179,14 @@ func startTrafficMonitor() {
 				if stat.up <= 0 && stat.down <= 0 {
 					continue
 				}
-				if _, err := db.Exec(`INSERT INTO node_traffic_history (node_id, up_bytes, down_bytes) VALUES (?, ?, ?)`, nodeID, stat.up, stat.down); err != nil {
+				if _, err := getDB().Exec(`INSERT INTO node_traffic_history (node_id, up_bytes, down_bytes) VALUES (?, ?, ?)`, nodeID, stat.up, stat.down); err != nil {
 					log.Printf("[WARN] insert node_traffic_history failed node=%d err=%v", nodeID, err)
 				}
 			}
-			if _, err := db.Exec(`DELETE FROM traffic_history WHERE ts < datetime('now', '-180 days')`); err != nil {
+			if _, err := getDB().Exec(`DELETE FROM traffic_history WHERE ts < datetime('now', '-180 days')`); err != nil {
 				log.Printf("[WARN] prune traffic_history failed: %v", err)
 			}
-			if _, err := db.Exec(`DELETE FROM node_traffic_history WHERE ts < datetime('now', '-180 days')`); err != nil {
+			if _, err := getDB().Exec(`DELETE FROM node_traffic_history WHERE ts < datetime('now', '-180 days')`); err != nil {
 				log.Printf("[WARN] prune node_traffic_history failed: %v", err)
 			}
 		}

--- a/backend/xray_default_fallback_test.go
+++ b/backend/xray_default_fallback_test.go
@@ -10,7 +10,7 @@ import (
 func renderXrayConfigForFallbackTest(t *testing.T, mode, lanPolicy, failoverMode string, nodeActive bool) map[string]any {
 	t.Helper()
 	tdb, _ := setupTestDB(t)
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() { db.Close() })
 
 	if _, err := db.Exec(`INSERT OR REPLACE INTO settings(key,value) VALUES ('mode',?)`, mode); err != nil {

--- a/backend/xray_nodes_dynamic.go
+++ b/backend/xray_nodes_dynamic.go
@@ -26,7 +26,7 @@ func applyNodeChangeDynamically(extraRemoveTags ...string) error {
 
 func syncXrayOutboundsDynamically(extraRemoveTags ...string) error {
 	removeTags := map[string]struct{}{}
-	rows, err := db.Query("SELECT id FROM nodes")
+	rows, err := getDB().Query("SELECT id FROM nodes")
 	if err != nil {
 		return fmt.Errorf("query node ids failed: %w", err)
 	}

--- a/backend/xray_routing_dynamic.go
+++ b/backend/xray_routing_dynamic.go
@@ -28,7 +28,7 @@ func applyRuleChangeDynamically(needMosdns bool) error {
 
 func getActiveNodeContext() (map[int]struct{}, int) {
 	active := map[int]struct{}{}
-	rows, err := db.Query("SELECT id FROM nodes WHERE active=1")
+	rows, err := getDB().Query("SELECT id FROM nodes WHERE active=1")
 	if err == nil {
 		defer rows.Close()
 		for rows.Next() {
@@ -40,7 +40,7 @@ func getActiveNodeContext() (map[int]struct{}, int) {
 	}
 
 	var defNodeStr string
-	_ = db.QueryRow("SELECT value FROM settings WHERE key='default_node_id'").Scan(&defNodeStr)
+	_ = getDB().QueryRow("SELECT value FROM settings WHERE key='default_node_id'").Scan(&defNodeStr)
 	defaultID, _ := strconv.Atoi(strings.TrimSpace(defNodeStr))
 	if _, ok := active[defaultID]; !ok {
 		defaultID = 0
@@ -90,12 +90,12 @@ func outboundTagForPolicy(policy string, active map[int]struct{}, defaultID int,
 
 func syncXrayRoutingRulesDynamically() error {
 	var mode string
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode); err != nil {
 		mode = "A"
 	}
 	active, defaultID := getActiveNodeContext()
 	var failoverMode string
-	_ = db.QueryRow("SELECT value FROM settings WHERE key='node_failover_mode'").Scan(&failoverMode)
+	_ = getDB().QueryRow("SELECT value FROM settings WHERE key='node_failover_mode'").Scan(&failoverMode)
 	strictFailover := normalizeNodeFailoverMode(strings.TrimSpace(strings.ToLower(failoverMode))) == "strict"
 	cfg := map[string]interface{}{
 		"routing": map[string]interface{}{
@@ -110,7 +110,7 @@ func syncXrayRoutingRulesDynamically() error {
 		)
 	}
 
-	rRows, err := db.Query("SELECT id, type, value, policy FROM rules ORDER BY priority ASC, id ASC")
+	rRows, err := getDB().Query("SELECT id, type, value, policy FROM rules ORDER BY priority ASC, id ASC")
 	if err != nil {
 		return fmt.Errorf("query rules failed: %w", err)
 	}

--- a/backend/xray_routing_dynamic_test.go
+++ b/backend/xray_routing_dynamic_test.go
@@ -41,7 +41,7 @@ func TestBuildXrayDomainRuleValues(t *testing.T) {
 
 func TestSyncXrayRoutingRulesDynamicallySupportsDomainWildcard(t *testing.T) {
 	tdb, _ := setupTestDB(t)
-	db = tdb
+	setDB(tdb)
 	t.Cleanup(func() { db.Close() })
 	_, err := db.Exec(`DELETE FROM rules; INSERT INTO rules(type, value, policy) VALUES ('domain', '*.c.com', 'proxy')`)
 	if err != nil {

--- a/backend/xray_service.go
+++ b/backend/xray_service.go
@@ -121,16 +121,16 @@ func applyXrayConfigInternal(restart bool) error {
 	}
 
 	var mode string
-	db.QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
+	getDB().QueryRow("SELECT value FROM settings WHERE key='mode'").Scan(&mode)
 	config := buildBaseXrayConfig(mode)
 
-	rows, err := db.Query("SELECT id, name, type, address, port, uuid, COALESCE(params, '{}'), active FROM nodes")
+	rows, err := getDB().Query("SELECT id, name, type, address, port, uuid, COALESCE(params, '{}'), active FROM nodes")
 	if err != nil {
 		return err
 	}
 	defer rows.Close()
 	var defNodeStr string
-	db.QueryRow("SELECT value FROM settings WHERE key='default_node_id'").Scan(&defNodeStr)
+	getDB().QueryRow("SELECT value FROM settings WHERE key='default_node_id'").Scan(&defNodeStr)
 	defaultNodeId, _ := strconv.Atoi(defNodeStr)
 
 	var activeIds []int
@@ -240,7 +240,7 @@ func applyXrayConfigInternal(restart bool) error {
 		}
 	}
 
-	rRows, err := db.Query("SELECT id, type, value, policy FROM rules ORDER BY priority ASC, id ASC")
+	rRows, err := getDB().Query("SELECT id, type, value, policy FROM rules ORDER BY priority ASC, id ASC")
 	if err != nil {
 		log.Printf("[WARN] routing rules query err: %v", err)
 		return err
@@ -314,11 +314,11 @@ func applyXrayConfigInternal(restart bool) error {
 	}
 
 	defaultPolicy := "proxy"
-	if err := db.QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil || strings.TrimSpace(defaultPolicy) == "" {
+	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil || strings.TrimSpace(defaultPolicy) == "" {
 		defaultPolicy = "proxy"
 	}
 	var failoverMode string
-	_ = db.QueryRow("SELECT value FROM settings WHERE key='node_failover_mode'").Scan(&failoverMode)
+	_ = getDB().QueryRow("SELECT value FROM settings WHERE key='node_failover_mode'").Scan(&failoverMode)
 	strictFailover := normalizeNodeFailoverMode(strings.TrimSpace(strings.ToLower(failoverMode))) == "strict"
 	catchAllRule := map[string]interface{}{
 		"type":    "field",


### PR DESCRIPTION
## 变更
1. **新增 backend CI**：PR/main push 命中 `backend/**` 时运行 `go vet` / `go build` / `go test` / `go test -race`。使用 `go.mod` 声明的 Go 版本，`CGO_ENABLED=1` 编译 go-sqlite3。
2. **修复 CI 抓到的 3 个既有数据竞争**：测试重写全局 `db`/`remoteConnect` 与后台 goroutine 并发读冲突。用 `sync.RWMutex` + `getDB/setDB`、`getRemoteConnect/setRemoteConnect` 保护全局。
3. **release.yml**：`go-version` 1.24 → 1.25，与 go.mod 对齐。

## 验证
Debian 容器内 Go 1.25.0 全量 `go build` / `go vet` / `go test -race ./...` 全绿。

Closes #15