### PR TITLE
ci: bump actions to Node-24-native versions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -25,10 +25,10 @@ jobs:
       CGO_ENABLED: '1'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache-dependency-path: backend/go.sum
@@ -46,7 +46,7 @@ jobs:
           test -s /tmp/release_notes.md
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ contains(github.ref_name, '-rc.') && format('EdgeRouteGW {0} Pre-release', github.ref_name) || format('EdgeRouteGW {0} Stable', github.ref_name) }}
           prerelease: ${{ contains(github.ref_name, '-rc.') }}

--- a/.github/workflows/update-cores.yml
+++ b/.github/workflows/update-cores.yml
@@ -15,7 +15,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download Latest Xray-Core
         run: |


### PR DESCRIPTION
修复 GitHub Actions 的 Node.js 20 弃用告警：

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-go@v5.
```

## 变更
- `actions/checkout@v4` → `@v5`（Node 24 迁移版）
- `actions/setup-go@v5` → `@v6`（Node 24 迁移版）
- `softprops/action-gh-release@v2` → `@v3`

涉及 3 个 workflow：backend-ci.yml / release.yml / update-cores.yml。

## 备注
- 保留了 `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` 环境变量（现在 action 原生就是 Node 24，该变量已冗余，可后续移除）。
- 若想用绝对最新版，checkout 最新为 v7、setup-go 最新为 v7，本次取的是迁移版本 v5/v6（更稳妥）。