### PR TITLE
security: validate LAN ACL input, secure xray temp file (audit fixes)

### DIFF
--- a/backend/lan_acl_controller.go
+++ b/backend/lan_acl_controller.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"net"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -45,6 +47,31 @@ func (ctl *LanACLController) Create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "bad request"})
 		return
 	}
+
+	// The value is interpolated verbatim into the nftables set template
+	// (applyNftablesConfig), so it must be a well-formed MAC or IP/CIDR — an
+	// arbitrary string could corrupt or inject into the generated ruleset.
+	req.Type = strings.ToLower(strings.TrimSpace(req.Type))
+	req.Policy = strings.ToLower(strings.TrimSpace(req.Policy))
+	req.Value = strings.TrimSpace(req.Value)
+	if req.Type != "mac" && req.Type != "ip" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid type (mac|ip)"})
+		return
+	}
+	if req.Policy != "proxy" && req.Policy != "direct" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid policy (proxy|direct)"})
+		return
+	}
+	if req.Type == "mac" {
+		if _, err := net.ParseMAC(req.Value); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid MAC address"})
+			return
+		}
+	} else if !isValidIPOrCIDR(req.Value) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid IP/CIDR"})
+		return
+	}
+
 	if err := ctl.repo.Create(req.Type, req.Value, req.Policy, req.Remark); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to add acl"})
 		return

--- a/backend/lan_acl_controller_test.go
+++ b/backend/lan_acl_controller_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLanACLCreateValidatesInput(t *testing.T) {
+	r := setupFeatureSuiteRouter(t)
+
+	reject := []struct {
+		name string
+		body string
+	}{
+		{"bad mac", `{"type":"mac","value":"not-a-mac","policy":"proxy"}`},
+		{"bad ip", `{"type":"ip","value":"999.999.1.1","policy":"direct"}`},
+		{"template injection", `{"type":"ip","value":"1.1.1.1 }; table inet evil {}","policy":"direct"}`},
+		{"bad type", `{"type":"host","value":"1.1.1.1","policy":"proxy"}`},
+		{"bad policy", `{"type":"ip","value":"1.1.1.1","policy":"evil"}`},
+	}
+	for _, tc := range reject {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, authedJSONRequest(http.MethodPost, "/api/lan_acls", tc.body))
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("%s: want 400 got %d body=%s", tc.name, w.Code, w.Body.String())
+		}
+	}
+
+	// Valid MAC/IP must pass validation (they then fail later at nft apply,
+	// since nft is unavailable in tests — so we only assert they are NOT 400).
+	accept := []string{
+		`{"type":"mac","value":"aa:bb:cc:dd:ee:ff","policy":"proxy"}`,
+		`{"type":"ip","value":"1.2.3.4/32","policy":"direct"}`,
+	}
+	for _, body := range accept {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, authedJSONRequest(http.MethodPost, "/api/lan_acls", body))
+		if w.Code == http.StatusBadRequest {
+			t.Fatalf("valid input wrongly rejected: body=%s resp=%s", body, w.Body.String())
+		}
+	}
+}

--- a/backend/xray_service.go
+++ b/backend/xray_service.go
@@ -453,8 +453,19 @@ func applyXrayConfigInternal(restart bool) error {
 
 	configData, _ := json.MarshalIndent(config, "", "  ")
 
-	tempTestPath := "/tmp/proxygw_xray_test.json"
-	os.WriteFile(tempTestPath, configData, 0644)
+	tmpTest, err := os.CreateTemp("", "proxygw_xray_test-*.json")
+	if err != nil {
+		return fmt.Errorf("failed to create temp xray test config: %v", err)
+	}
+	tempTestPath := tmpTest.Name()
+	defer os.Remove(tempTestPath)
+	if _, err := tmpTest.Write(configData); err != nil {
+		tmpTest.Close()
+		return fmt.Errorf("failed to write temp xray test config: %v", err)
+	}
+	if err := tmpTest.Close(); err != nil {
+		return fmt.Errorf("failed to close temp xray test config: %v", err)
+	}
 	if err := sysCmd.run(getPath("core", "xray", "xray"), "-test", "-config", tempTestPath); err != nil {
 		log.Printf("[ERROR] Xray config validation failed: %v. Config rejected.", err)
 		return fmt.Errorf("xray config validation failed, check node parameters")


### PR DESCRIPTION
修复审计发现的两项可落地安全问题：

1. **LAN ACL 模板注入（CWE-77）**：`lan_acl_controller.go Create` 此前直接入库未校验 `value`，而 `applyNftablesConfig` 把它原样插值进 nftables set 模板。新增校验：type∈{mac,ip}、policy∈{proxy,direct}、MAC 经 `net.ParseMAC`、IP/CIDR 经 `isValidIPOrCIDR`。附带回归测试（含模板注入 payload 拒绝用例）。

2. **硬编码临时路径 TOCTOU（CWE-377）**：`xray_service.go` 用固定 `/tmp/proxygw_xray_test.json`，改用 `os.CreateTemp`（随机名、0600、用完清理），并补上之前被忽略的写文件错误处理。

注：审计另发现 **mosdns 二进制下载无完整性校验**（`update_controller.go:120` 传空 hash），但 mosdns 官方 release 不提供任何校验文件（仅 .zip），无法用 fetch-hash 方式修复，故仅在报告中标注；xray/geodata 已有 SHA256 校验。

测试：build/vet/test 全绿，新增 `TestLanACLCreateValidatesInput` 通过。