### PR TITLE
feat: allow configurable listen address via PROXYGW_LISTEN_ADDR

### DIFF
--- a/backend/app_controller.go
+++ b/backend/app_controller.go
@@ -43,8 +43,12 @@ func (c *AppController) BuildRouter() *gin.Engine {
 }
 
 func (c *AppController) Run(r *gin.Engine) {
-	log.Println("EdgeRouteGW backend starting on :80")
-	r.Run(":80")
+	addr := os.Getenv("PROXYGW_LISTEN_ADDR")
+	if addr == "" {
+		addr = ":80"
+	}
+	log.Printf("EdgeRouteGW backend starting on %s", addr)
+	r.Run(addr)
 }
 
 func getLogWriter() gin.HandlerFunc {


### PR DESCRIPTION
后端此前硬编码 `:80`，在 rootless 容器或 80 端口被占用/无权限的主机上无法启动。

改动：读取 `PROXYGW_LISTEN_ADDR` 环境变量，缺省 `:80`。这样容器化/测试部署可用 `PROXYGW_LISTEN_ADDR=:8080` 覆盖，无需改代码。默认行为不变（仍为 :80）。