### PR TITLE
feat(remote-deploy): harden REALITY parameters against misconfiguration

### DIFF
--- a/backend/remote_deploy/validation.go
+++ b/backend/remote_deploy/validation.go
@@ -1,0 +1,152 @@
+package remote_deploy
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// DefaultRealityPort is the listen port used for a REALITY inbound unless the
+// operator explicitly picks another one.
+//
+// REALITY's camouflage rests on the node being indistinguishable from an
+// ordinary TLS reverse proxy for serverName. No real deployment reverse-proxies
+// a major site on a random high port, so a port outside the usual TLS range is
+// a stronger fingerprint than anything visible at the SNI layer. 443 is the
+// only value that keeps that premise intact.
+const DefaultRealityPort = 443
+
+// DefaultRealityServerName / DefaultRealityDest are the fallback camouflage
+// target. They are a last resort only: every install that accepts the default
+// points at the same dest, which is itself a cross-deployment fingerprint.
+// Callers should prefer an operator-supplied value.
+const (
+	DefaultRealityServerName = "www.microsoft.com"
+	DefaultRealityDest       = "www.microsoft.com:443"
+)
+
+// maxHostnameLen is the maximum length of a DNS name in presentation format.
+const maxHostnameLen = 253
+
+// ValidateRealityServerName checks that s is a single, syntactically valid DNS
+// hostname usable as a REALITY serverNames entry.
+//
+// REALITY matches the client's SNI against serverNames verbatim. An empty or
+// malformed entry cannot match anything, so every connection — including the
+// gateway's own — silently falls through to dest and the node is dead while
+// still reporting a successful deploy. Rejecting it up front turns that into a
+// deploy-time error instead of a silent outage.
+//
+// IP literals are rejected: an SNI is a name, and a certificate presented for
+// an IP would not validate against it.
+func ValidateRealityServerName(s string) error {
+	if s == "" {
+		return fmt.Errorf("reality serverName must not be empty")
+	}
+	if strings.TrimSpace(s) != s {
+		return fmt.Errorf("reality serverName %q must not contain leading or trailing whitespace", s)
+	}
+	if len(s) > maxHostnameLen {
+		return fmt.Errorf("reality serverName %q exceeds %d characters", s, maxHostnameLen)
+	}
+	if net.ParseIP(s) != nil {
+		return fmt.Errorf("reality serverName %q must be a domain name, not an IP literal", s)
+	}
+	// A bare label ("localhost") is never a usable camouflage target: no public
+	// certificate authority issues for it and no real reverse proxy serves it.
+	if !strings.Contains(s, ".") {
+		return fmt.Errorf("reality serverName %q must be a fully qualified domain name", s)
+	}
+	if strings.HasSuffix(s, ".") {
+		return fmt.Errorf("reality serverName %q must not be a rooted domain name", s)
+	}
+	for _, label := range strings.Split(s, ".") {
+		if err := validateHostnameLabel(label, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateHostnameLabel(label, host string) error {
+	if label == "" {
+		return fmt.Errorf("hostname %q contains an empty label", host)
+	}
+	if len(label) > 63 {
+		return fmt.Errorf("hostname %q contains a label longer than 63 characters", host)
+	}
+	if label[0] == '-' || label[len(label)-1] == '-' {
+		return fmt.Errorf("hostname %q contains a label with a leading or trailing hyphen", host)
+	}
+	for i := 0; i < len(label); i++ {
+		c := label[i]
+		isAlphaNum := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+		if !isAlphaNum && c != '-' {
+			return fmt.Errorf("hostname %q contains an invalid character %q", host, string(c))
+		}
+	}
+	return nil
+}
+
+// ValidateRealityDest checks that dest is a "host:port" pair REALITY can dial
+// as its fallback target. A dest that does not resolve to a real TLS listener
+// makes every probe — and every SNI miss — return an obviously broken
+// handshake, which is exactly the signal active probing looks for.
+//
+// The host half may be a domain name or an IP literal (IPv6 in brackets);
+// unlike serverName, dest is dialled rather than matched against a certificate.
+func ValidateRealityDest(dest string) error {
+	if dest == "" {
+		return fmt.Errorf("reality dest must not be empty")
+	}
+	if strings.TrimSpace(dest) != dest {
+		return fmt.Errorf("reality dest %q must not contain leading or trailing whitespace", dest)
+	}
+	host, portStr, err := net.SplitHostPort(dest)
+	if err != nil {
+		return fmt.Errorf("reality dest %q must be in host:port form: %w", dest, err)
+	}
+	if host == "" {
+		return fmt.Errorf("reality dest %q has an empty host", dest)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fmt.Errorf("reality dest %q has a non-numeric port %q", dest, portStr)
+	}
+	if err := ValidatePort(port); err != nil {
+		return fmt.Errorf("reality dest %q: %w", dest, err)
+	}
+	if net.ParseIP(host) != nil {
+		return nil
+	}
+	if len(host) > maxHostnameLen {
+		return fmt.Errorf("reality dest host %q exceeds %d characters", host, maxHostnameLen)
+	}
+	for _, label := range strings.Split(strings.TrimSuffix(host, "."), ".") {
+		if err := validateHostnameLabel(label, host); err != nil {
+			return fmt.Errorf("reality dest: %w", err)
+		}
+	}
+	return nil
+}
+
+// ValidatePort checks that p is a port a service can listen on or dial.
+func ValidatePort(p int) error {
+	if p < 1 || p > 65535 {
+		return fmt.Errorf("port %d out of range 1-65535", p)
+	}
+	return nil
+}
+
+// ValidateRealityParams validates a full REALITY inbound parameter set before
+// it is baked into an install script and executed as root on a remote host.
+func ValidateRealityParams(port int, serverName, dest string) error {
+	if err := ValidatePort(port); err != nil {
+		return err
+	}
+	if err := ValidateRealityServerName(serverName); err != nil {
+		return err
+	}
+	return ValidateRealityDest(dest)
+}

--- a/backend/remote_deploy/validation_test.go
+++ b/backend/remote_deploy/validation_test.go
@@ -1,0 +1,147 @@
+package remote_deploy
+
+import "testing"
+
+type namedCase struct {
+	label string
+	value string
+}
+
+func TestValidateRealityServerNameAcceptsRealHostnames(t *testing.T) {
+	valid := []string{
+		"www.microsoft.com",
+		"dl.google.com",
+		"a.co",
+		"xn--fiqs8s.example.com",
+		"my-cdn-01.edge.example.org",
+	}
+	for _, name := range valid {
+		if err := ValidateRealityServerName(name); err != nil {
+			t.Errorf("ValidateRealityServerName(%q) = %v, want nil", name, err)
+		}
+	}
+}
+
+func TestValidateRealityServerNameRejectsUnusableValues(t *testing.T) {
+	// Each of these silently breaks REALITY matching: nothing ever equals the
+	// configured serverName, so every connection falls through to dest while
+	// the deploy still reports success.
+	invalid := []namedCase{
+		{"empty", ""},
+		{"whitespace only", " "},
+		{"leading space", " www.microsoft.com"},
+		{"trailing space", "www.microsoft.com "},
+		{"inner space", "www.micro soft.com"},
+		{"bare label", "localhost"},
+		{"IPv4 literal", "93.184.216.34"},
+		{"IPv6 literal", "2606:2800:220:1:248:1893:25c8:1946"},
+		{"rooted", "www.microsoft.com."},
+		{"empty label", "www..com"},
+		{"leading hyphen", "-www.microsoft.com"},
+		{"trailing hyphen", "www-.microsoft.com"},
+		{"underscore", "www_cdn.microsoft.com"},
+		{"scheme prefixed", "https://www.microsoft.com"},
+		{"host:port pair", "www.microsoft.com:443"},
+		{"path appended", "www.microsoft.com/index.html"},
+		{"comma separated", "www.microsoft.com,www.apple.com"},
+		{"newline injected", "www.microsoft.com\nevil.example.com"},
+	}
+	for _, tc := range invalid {
+		if err := ValidateRealityServerName(tc.value); err == nil {
+			t.Errorf("ValidateRealityServerName(%q) [%s] = nil, want error", tc.value, tc.label)
+		}
+	}
+}
+
+func TestValidateRealityServerNameRejectsOverlongNames(t *testing.T) {
+	long := ""
+	for i := 0; i < 26; i++ {
+		long += "abcdefghij."
+	}
+	long += "com" // 289 characters
+	if err := ValidateRealityServerName(long); err == nil {
+		t.Error("ValidateRealityServerName(<289 chars>) = nil, want error")
+	}
+
+	longLabel := ""
+	for i := 0; i < 64; i++ {
+		longLabel += "a"
+	}
+	if err := ValidateRealityServerName(longLabel + ".com"); err == nil {
+		t.Error("ValidateRealityServerName(<64-char label>) = nil, want error")
+	}
+}
+
+func TestValidateRealityDestAcceptsDialableTargets(t *testing.T) {
+	valid := []string{
+		"www.microsoft.com:443",
+		"dl.google.com:443",
+		"93.184.216.34:443",
+		"[2606:2800:220:1:248:1893:25c8:1946]:443",
+		"example.com:8443",
+	}
+	for _, dest := range valid {
+		if err := ValidateRealityDest(dest); err != nil {
+			t.Errorf("ValidateRealityDest(%q) = %v, want nil", dest, err)
+		}
+	}
+}
+
+func TestValidateRealityDestRejectsMalformedTargets(t *testing.T) {
+	invalid := []namedCase{
+		{"empty", ""},
+		{"no port", "www.microsoft.com"},
+		{"empty host", ":443"},
+		{"empty port", "www.microsoft.com:"},
+		{"non-numeric port", "www.microsoft.com:https"},
+		{"port zero", "www.microsoft.com:0"},
+		{"port out of range", "www.microsoft.com:65536"},
+		{"negative port", "www.microsoft.com:-1"},
+		{"scheme prefixed", "https://www.microsoft.com:443"},
+		{"unbracketed IPv6", "2606:2800:220:1:248:1893:25c8:1946:443"},
+		{"trailing space", "www.microsoft.com:443 "},
+		{"underscore host", "www_cdn.microsoft.com:443"},
+		{"newline injected", "www.microsoft.com:443\nevil.example.com:443"},
+	}
+	for _, tc := range invalid {
+		if err := ValidateRealityDest(tc.value); err == nil {
+			t.Errorf("ValidateRealityDest(%q) [%s] = nil, want error", tc.value, tc.label)
+		}
+	}
+}
+
+func TestValidatePortRange(t *testing.T) {
+	for _, p := range []int{1, 443, 65535} {
+		if err := ValidatePort(p); err != nil {
+			t.Errorf("ValidatePort(%d) = %v, want nil", p, err)
+		}
+	}
+	for _, p := range []int{0, -1, 65536, 1 << 20} {
+		if err := ValidatePort(p); err == nil {
+			t.Errorf("ValidatePort(%d) = nil, want error", p)
+		}
+	}
+}
+
+func TestValidateRealityParamsRejectsEachBadField(t *testing.T) {
+	if err := ValidateRealityParams(DefaultRealityPort, DefaultRealityServerName, DefaultRealityDest); err != nil {
+		t.Fatalf("ValidateRealityParams(defaults) = %v, want nil", err)
+	}
+	if err := ValidateRealityParams(0, DefaultRealityServerName, DefaultRealityDest); err == nil {
+		t.Error("ValidateRealityParams with port 0 = nil, want error")
+	}
+	if err := ValidateRealityParams(DefaultRealityPort, "", DefaultRealityDest); err == nil {
+		t.Error("ValidateRealityParams with empty serverName = nil, want error")
+	}
+	if err := ValidateRealityParams(DefaultRealityPort, DefaultRealityServerName, "www.microsoft.com"); err == nil {
+		t.Error("ValidateRealityParams with portless dest = nil, want error")
+	}
+}
+
+func TestDefaultRealityPortIs443(t *testing.T) {
+	// A REALITY inbound on a random high port contradicts its own cover story:
+	// no real deployment reverse-proxies a major site outside the TLS ports.
+	if DefaultRealityPort != 443 {
+		t.Errorf("DefaultRealityPort = %d, want 443", DefaultRealityPort)
+	}
+}

--- a/backend/remote_node_reality_params_test.go
+++ b/backend/remote_node_reality_params_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func realityDeployReq() RemoteNodeReq {
+	return RemoteNodeReq{
+		Name:          "192.168.20.152",
+		Type:          "vless",
+		SSHHost:       "192.168.20.152",
+		SSHPort:       22,
+		SSHUser:       "root",
+		SSHHostKey:    "SHA256:test",
+		SSHAuthType:   "password",
+		SSHCredential: "secret123",
+		Region:        "lab",
+		Remark:        "seed",
+	}
+}
+
+// stubSuccessfulSSH installs a connector whose RunCommand always succeeds and
+// records every command it was handed.
+func stubSuccessfulSSH(t *testing.T, ran *[]string) {
+	t.Helper()
+	oldConnect := getRemoteConnect()
+	t.Cleanup(func() { setRemoteConnect(oldConnect) })
+	setRemoteConnect(func(host string, port int, user string, authType string, credential string, expectedHostKey string) (remoteSSHClient, error) {
+		return &fakeSSHClient{run: func(cmd string) (string, string, error) {
+			*ran = append(*ran, cmd)
+			return "", "", nil
+		}}, nil
+	})
+}
+
+func TestDoDeployRoutine_VlessDefaultsToPort443(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	var ran []string
+	stubSuccessfulSSH(t, &ran)
+
+	doDeployRoutine(2, realityDeployReq(), true, nil)
+
+	var port int
+	var serverName, dest string
+	if err := db.QueryRow("SELECT port, server_name, dest FROM remote_node_vless WHERE node_id = 2").
+		Scan(&port, &serverName, &dest); err != nil {
+		t.Fatal(err)
+	}
+	// A REALITY inbound on a random high port contradicts its own cover story,
+	// so a deploy that names no port must land on 443 rather than on whatever
+	// the port allocator happened to pick.
+	if port != 443 {
+		t.Errorf("default REALITY port = %d, want 443", port)
+	}
+	if serverName != "www.microsoft.com" {
+		t.Errorf("default serverName = %q, want www.microsoft.com", serverName)
+	}
+	if dest != "www.microsoft.com:443" {
+		t.Errorf("default dest = %q, want www.microsoft.com:443", dest)
+	}
+}
+
+func TestDoDeployRoutine_VlessHonoursExplicitOverrides(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	var ran []string
+	stubSuccessfulSSH(t, &ran)
+
+	req := realityDeployReq()
+	req.Port = 8443
+	req.ServerName = "dl.google.com"
+	req.Dest = "dl.google.com:443"
+
+	doDeployRoutine(2, req, true, nil)
+
+	var port int
+	var serverName, dest, shareLink string
+	if err := db.QueryRow("SELECT port, server_name, dest, share_link FROM remote_node_vless WHERE node_id = 2").
+		Scan(&port, &serverName, &dest, &shareLink); err != nil {
+		t.Fatal(err)
+	}
+	if port != 8443 {
+		t.Errorf("port = %d, want 8443 (explicit override)", port)
+	}
+	if serverName != "dl.google.com" {
+		t.Errorf("serverName = %q, want dl.google.com", serverName)
+	}
+	if dest != "dl.google.com:443" {
+		t.Errorf("dest = %q, want dl.google.com:443", dest)
+	}
+	if !strings.Contains(shareLink, "sni=dl.google.com") {
+		t.Errorf("share link does not carry the overridden sni: %s", shareLink)
+	}
+}
+
+func TestDoDeployRoutine_VlessRejectsMalformedParamsBeforeRunningScript(t *testing.T) {
+	cases := []struct {
+		label      string
+		serverName string
+		dest       string
+		port       int
+	}{
+		{"serverName with inner space", "www.micro soft.com", "www.microsoft.com:443", 443},
+		{"serverName with port", "www.microsoft.com:443", "www.microsoft.com:443", 443},
+		{"serverName as IP", "93.184.216.34", "www.microsoft.com:443", 443},
+		{"bare-label serverName", "localhost", "www.microsoft.com:443", 443},
+		{"dest without port", "www.microsoft.com", "www.microsoft.com", 443},
+		{"dest with bad port", "www.microsoft.com", "www.microsoft.com:0", 443},
+		{"port out of range", "www.microsoft.com", "www.microsoft.com:443", 70000},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			setupFeatureSuiteRouter(t)
+			var ran []string
+			stubSuccessfulSSH(t, &ran)
+
+			req := realityDeployReq()
+			req.Port = tc.port
+			req.ServerName = tc.serverName
+			req.Dest = tc.dest
+
+			doDeployRoutine(2, req, true, nil)
+
+			// The install script is what carries these values onto the remote
+			// host as root, so rejection has to happen before it is run.
+			if len(ran) != 0 {
+				t.Errorf("install script ran despite invalid params: %v", ran)
+			}
+
+			var status string
+			if err := db.QueryRow("SELECT status FROM remote_nodes WHERE id = 2").Scan(&status); err != nil {
+				t.Fatal(err)
+			}
+			if status != "Failed" {
+				t.Errorf("status = %s, want Failed", status)
+			}
+
+			var logText string
+			if err := db.QueryRow("SELECT log_text FROM remote_node_logs WHERE node_id = 2 ORDER BY id DESC LIMIT 1").
+				Scan(&logText); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(logText, "Invalid REALITY parameters") {
+				t.Errorf("log does not explain the rejection: %s", logText)
+			}
+		})
+	}
+}
+
+func TestDoDeployRoutine_VlessShareLinkEscapesParameters(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	var ran []string
+	stubSuccessfulSSH(t, &ran)
+
+	doDeployRoutine(2, realityDeployReq(), true, nil)
+
+	var shareLink string
+	if err := db.QueryRow("SELECT share_link FROM remote_node_vless WHERE node_id = 2").Scan(&shareLink); err != nil {
+		t.Fatal(err)
+	}
+	// The query string ends at the fragment; every parameter before it must be
+	// a single well-formed key=value pair.
+	query := shareLink
+	if i := strings.Index(query, "#"); i >= 0 {
+		query = query[:i]
+	}
+	i := strings.Index(query, "?")
+	if i < 0 {
+		t.Fatalf("share link has no query string: %s", shareLink)
+	}
+	for _, pair := range strings.Split(query[i+1:], "&") {
+		if strings.Count(pair, "=") != 1 {
+			t.Errorf("malformed share link parameter %q in %s", pair, shareLink)
+		}
+	}
+}
+
+func TestDoDeployRoutine_VlessTreatsBlankOverridesAsUnset(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	var ran []string
+	stubSuccessfulSSH(t, &ran)
+
+	req := realityDeployReq()
+	req.ServerName = "   "
+	req.Dest = "  "
+
+	doDeployRoutine(2, req, true, nil)
+
+	var serverName, dest string
+	if err := db.QueryRow("SELECT server_name, dest FROM remote_node_vless WHERE node_id = 2").
+		Scan(&serverName, &dest); err != nil {
+		t.Fatal(err)
+	}
+	// A form field the operator left blank must fall back to the default rather
+	// than deploy a serverName no SNI can ever match.
+	if serverName != "www.microsoft.com" || dest != "www.microsoft.com:443" {
+		t.Errorf("blank overrides gave serverName=%q dest=%q, want the defaults", serverName, dest)
+	}
+}

--- a/backend/remote_nodes_controller.go
+++ b/backend/remote_nodes_controller.go
@@ -25,6 +25,14 @@ type RemoteNodeReq struct {
 	SSHCredential string `json:"ssh_credential"`
 	Region        string `json:"region"`
 	Remark        string `json:"remark"`
+
+	// Optional REALITY overrides, honoured only on a fresh deploy. Left unset,
+	// each falls back to the package default in remote_deploy. Port is an
+	// advanced knob: anything other than 443 weakens the camouflage, because a
+	// real reverse proxy for ServerName would not be reachable there.
+	Port       int    `json:"port"`
+	ServerName string `json:"server_name"`
+	Dest       string `json:"dest"`
 }
 
 type remoteSSHClient interface {
@@ -334,12 +342,26 @@ func doDeployRoutine(id int64, req RemoteNodeReq, isUpdate bool, params map[stri
 		var port int
 
 		if params == nil {
-			port, _ = remote_deploy.GenerateUniquePort(db, 10000, 60000)
+			// REALITY only stays hidden while the node is indistinguishable
+			// from an ordinary TLS reverse proxy for serverName. Nobody
+			// reverse-proxies a major site on a random high port, so the port
+			// is a stronger fingerprint than anything at the SNI layer:
+			// default to 443 and treat any other value as a deliberate choice.
+			port = req.Port
+			if port == 0 {
+				port = remote_deploy.DefaultRealityPort
+			}
 			rPriv, rPub, _ = remote_deploy.GenerateXrayRealityKeys()
 			uuid = remote_deploy.GenerateUUID()
 			shortId, _ = remote_deploy.GenerateShortId()
-			dest = "www.microsoft.com:443"
-			serverName = "www.microsoft.com"
+			serverName = strings.TrimSpace(req.ServerName)
+			if serverName == "" {
+				serverName = remote_deploy.DefaultRealityServerName
+			}
+			dest = strings.TrimSpace(req.Dest)
+			if dest == "" {
+				dest = remote_deploy.DefaultRealityDest
+			}
 		} else {
 			if p, ok := params["port"].(float64); ok {
 				port = int(p)
@@ -364,8 +386,20 @@ func doDeployRoutine(id int64, req RemoteNodeReq, isUpdate bool, params map[stri
 			}
 		}
 
+		// Validate before these values are baked into a script that runs as root
+		// on the remote host. A malformed serverName or dest does not fail
+		// loudly at runtime: REALITY simply forwards every connection to dest,
+		// so the node reports a successful deploy while being either dead (no
+		// SNI can ever match) or trivially fingerprintable (dest does not serve
+		// serverName).
+		if err := remote_deploy.ValidateRealityParams(port, serverName, dest); err != nil {
+			NewRemoteNodesRepository().SetRemoteNodeStatus(id, "Failed")
+			logAction(id, "deploy", "failed", fmt.Sprintf("Invalid REALITY parameters: %v", err))
+			return
+		}
+
 		shareLink = fmt.Sprintf("vless://%s@%s:%d?security=reality&sni=%s&fp=chrome&pbk=%s&sid=%s&type=tcp&flow=xtls-rprx-vision&encryption=none#%s",
-			uuid, req.SSHHost, port, serverName, rPub, shortId, url.QueryEscape(req.Name))
+			uuid, req.SSHHost, port, url.QueryEscape(serverName), url.QueryEscape(rPub), url.QueryEscape(shortId), url.QueryEscape(req.Name))
 
 		if err := NewRemoteNodesRepository().UpsertRemoteNodeVLESSParams(id, uuid, rPriv, rPub, shortId, serverName, dest, port, shareLink); err != nil {
 			NewRemoteNodesRepository().SetRemoteNodeStatus(id, "Failed")

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -603,6 +603,30 @@ Example-2,wg,2.2.2.2,22,root,password,MySecret,JP"></textarea>
                                             </div>
                                         </div>
                                     </div>
+                                    <div v-if="remoteNodeForm.type === 'vless'" class="border-t pt-4">
+                                        <h4 class="font-medium text-gray-700 mb-2">REALITY 伪装参数</h4>
+                                        <div class="grid grid-cols-4 gap-4">
+                                            <div>
+                                                <label class="block text-sm font-medium text-gray-700 mb-1">监听端口</label>
+                                                <input v-model.number="remoteNodeForm.port" type="number" min="1" max="65535" class="w-full border p-2 rounded font-mono">
+                                            </div>
+                                            <div>
+                                                <label class="block text-sm font-medium text-gray-700 mb-1">SNI / serverName</label>
+                                                <input v-model="remoteNodeForm.server_name" type="text" class="w-full border p-2 rounded font-mono" placeholder="www.microsoft.com">
+                                            </div>
+                                            <div class="col-span-2">
+                                                <label class="block text-sm font-medium text-gray-700 mb-1">dest (回落目标 host:port)</label>
+                                                <input v-model="remoteNodeForm.dest" type="text" class="w-full border p-2 rounded font-mono" placeholder="www.microsoft.com:443">
+                                            </div>
+                                        </div>
+                                        <p class="text-xs text-gray-500 mt-2">
+                                            <i class="fa-solid fa-triangle-exclamation text-amber-500 mr-1"></i>
+                                            端口建议保持 <strong>443</strong>。REALITY 的伪装前提是这台机器看起来像一台普通的 TLS 反向代理，而真实世界不存在在高位随机端口上反代大站的服务器 —— 端口本身就是比 SNI 更强的特征。仅在 443 确实被占用时才改，并知晓伪装强度会下降。
+                                        </p>
+                                        <p class="text-xs text-gray-500 mt-1">
+                                            dest 必须真的为 serverName 提供证书，两者不匹配时主动探测一次握手即可识别。两项留空则使用默认值。
+                                        </p>
+                                    </div>
                                 </div>
                                 <div class="px-6 py-4 border-t bg-gray-50 flex justify-end space-x-3 rounded-b-lg">
                                     <button @click="showRemoteNodeModal = false" class="px-4 py-2 border rounded text-gray-600 hover:bg-gray-100 transition">取消</button>
@@ -1982,7 +2006,8 @@ window.onerror = function(msg, url, line, col, error) { alert("JS Error: " + msg
                 const selectedRemoteNode = ref(null);
                 const remoteNodeForm = ref({
                     name: '', type: 'vless', ssh_host: '', ssh_port: 22, ssh_user: 'root',
-                    ssh_auth_type: 'password', ssh_credential: '', region: '', remark: ''
+                    ssh_auth_type: 'password', ssh_credential: '', region: '', remark: '',
+                    port: 443, server_name: '', dest: ''
                 });
 
                 
@@ -2071,7 +2096,8 @@ window.onerror = function(msg, url, line, col, error) { alert("JS Error: " + msg
                 const openAddRemoteNode = () => {
                     remoteNodeForm.value = {
                         name: '', type: 'vless', ssh_host: '', ssh_port: 22, ssh_user: 'root',
-                        ssh_auth_type: 'password', ssh_credential: '', region: '', remark: ''
+                        ssh_auth_type: 'password', ssh_credential: '', region: '', remark: '',
+                        port: 443, server_name: '', dest: ''
                     };
                     showRemoteNodeModal.value = true;
                 };
@@ -2082,7 +2108,10 @@ window.onerror = function(msg, url, line, col, error) { alert("JS Error: " + msg
                         const res = await apiFetch('/api/remote_nodes', {
                             method: 'POST',
                             headers: {'Content-Type': 'application/json'},
-                            body: JSON.stringify(remoteNodeForm.value)
+                            body: JSON.stringify({
+                                ...remoteNodeForm.value,
+                                port: Number(remoteNodeForm.value.port) || 0
+                            })
                         });
                         const data = await res.json();
                         if (data.success) {


### PR DESCRIPTION
## 背景

远程 VLESS 节点是全自动 SSH 下发的，操作者在参数以 root 身份在远端执行之前，没有任何机会看到它们。其中两个参数完全没有校验，还有一个默认值在主动破坏 REALITY 自己的伪装前提。

参考 [hello-yunshu/Xray_bash_onekey](https://github.com/hello-yunshu/Xray_bash_onekey) 的 SNI Guard 设计思路。注意：SNI Guard 的具体机制（`ssl_reject_handshake`）**不适用**于本仓库 —— 它只在 Reality + Nginx 同机共存模式下启用（`[[ ${reality_add_nginx} != "on" ]] && return 0`），修的是 nginx 前置引入的问题。纯 Reality 下把未知 SNI 转发给 `dest` 恰恰是正确行为，套 `ssl_reject_handshake` 反而削弱伪装。本 PR 借鉴的是它底下那层：**参数严格校验 + 默认值不裸奔**。

## 改动

### 1. 监听端口默认 443

之前：`GenerateUniquePort(db, 10000, 60000)` —— Reality inbound 落在随机高位端口上。

REALITY 的伪装前提是这台机器看起来像一台普通的 TLS 反向代理。而真实世界不存在在 43127 端口上反代 `www.microsoft.com` 的服务器 —— 端口本身就是比 SNI 更强的特征，全端口扫一遍，高位端口上握手成功且证书是大厂域名的基本都是代理。SNI 层面伪装得再好也补不回来。

现在：新建部署默认 443；非 443 是显式的高级选择，UI 上写明伪装代价。

`remote_node_vless.port` 没有 UNIQUE 约束，且每个节点是独立主机，多节点共用 443 无冲突。

### 2. `serverName` / `dest` 严格校验

之前：从请求裸取，全仓库没有任何 validate。

这两个参数出错都**不会在运行时报错**：

- REALITY 把客户端 SNI 与 `serverNames` 逐字节比对。空值或畸形值匹配不到任何东西，于是**每一条**连接（包括网关自己的）都静默落到 `dest`，节点实际已死，但部署流程照样报成功。
- `dest` 若不是一个可拨号、且真为 `serverName` 提供证书的 `host:port`，每次 SNI miss 都会返回一个明显异常的握手 —— 这正是主动探测在找的信号。

现在：`remote_deploy.ValidateRealityParams(port, serverName, dest)` 在生成安装脚本**之前**校验，不通过则把节点标记为 Failed 并记录原因，而不是下发一个坏配置。

- `serverName`：单个合法 FQDN。拒绝空值/空白、内嵌空格、裸标签（`localhost`）、IP 字面量、根域点、空标签、首尾连字符、下划线、`host:port`、带 scheme/path、逗号分隔、换行注入、超长（>253）与超长标签（>63）。
- `dest`：`net.SplitHostPort` 可解析，host 为合法域名或 IP 字面量（IPv6 带方括号），端口 1–65535。
- 表单留空（或纯空白）视为"未提供"，回落到默认值，而不是下发一个匹配不到任何 SNI 的空 `serverName`。

### 3. 分享链接转义

`sni` / `pbk` / `sid` 之前是裸插值，值里含 `&` 或 `#` 会截断 `vless://` 链接。现在统一走 `url.QueryEscape`。

## 测试

- `backend/remote_deploy/validation_test.go` —— 校验器单测，覆盖上面列出的每一类畸形输入。
- `backend/remote_node_reality_params_test.go` —— 控制器层：默认落 443、显式覆盖生效、畸形参数在**安装脚本执行之前**被拒（断言 `RunCommand` 一次都没被调用）、空白覆盖回落默认、分享链接参数格式良好。

## 对现有安装的影响

重新部署一个 `server_name` 或 `dest` 本就畸形的节点，现在会带明确原因失败，而不是静默复现坏配置。这是有意为之 —— 那种节点本来就是坏的。

已有的随机高位端口节点不受影响：重新部署沿用库里存的端口，校验只检查范围。

## 未包含（后续）

- **部署后 TLS 自检**：连一次 `dest`，断言 TLS 1.3 / ALPN 含 h2 / 证书 SAN 覆盖 `serverName`，失败标 Failed。需要先想清楚 Mode B/C 下这个探测走哪条路由，别被 fakeip 兜回来。
- **`dest` 候选池随机化**：目前所有接受默认值的安装都指向同一个 `www.microsoft.com:443`，这本身是一个跨部署可聚类的特征。需要先定候选域名清单。
- **分享链接的 IPv6 host 未加方括号**：`vless://uuid@2001:db8::1:443?...` 是坏链接。同一行代码上的相邻问题，为控制本 PR 范围没有一并改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
