### PR TITLE
security: stop leaking node credentials through world-readable files

### DIFF
--- a/backend/xray_nodes_dynamic.go
+++ b/backend/xray_nodes_dynamic.go
@@ -68,8 +68,23 @@ func syncXrayOutboundsDynamically(extraRemoveTags ...string) error {
 	if err != nil {
 		return fmt.Errorf("marshal outbounds payload failed: %w", err)
 	}
-	tmpPath := "/tmp/proxygw_xray_outbounds.json"
-	if err := os.WriteFile(tmpPath, b, 0644); err != nil {
+	// This payload carries every outbound's credentials (VLESS UUIDs, Trojan and
+	// Shadowsocks passwords). A fixed world-readable path exposed them to any
+	// local reader whenever the backend runs outside its systemd unit, and let
+	// an unprivileged user pre-create the path as a symlink. Use an
+	// unpredictable name, keep it owner-only, and remove it once xray has read
+	// it back.
+	tmpFile, err := os.CreateTemp("", "proxygw_xray_outbounds_*.json")
+	if err != nil {
+		return fmt.Errorf("create outbounds payload failed: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmpFile.Write(b); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("write outbounds payload failed: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
 		return fmt.Errorf("write outbounds payload failed: %w", err)
 	}
 	if res := sysCmd.runCombinedOutput(getPath("core", "xray", "xray"), "api", "ado", "-s", "127.0.0.1:10085", tmpPath); res.Err != nil {

--- a/backend/xray_routing_dynamic.go
+++ b/backend/xray_routing_dynamic.go
@@ -158,8 +158,20 @@ func syncXrayRoutingRulesDynamically() error {
 	if err != nil {
 		return fmt.Errorf("marshal routing payload failed: %w", err)
 	}
-	tmp := "/tmp/proxygw_xray_routing_rules.json"
-	if err := os.WriteFile(tmp, payload, 0644); err != nil {
+	// A fixed path under /tmp can be pre-created as a symlink by any local user,
+	// which would redirect this root-owned write. Use an unpredictable name and
+	// clean it up once xray has read it back.
+	tmpFile, err := os.CreateTemp("", "proxygw_xray_routing_rules_*.json")
+	if err != nil {
+		return fmt.Errorf("create routing payload failed: %w", err)
+	}
+	tmp := tmpFile.Name()
+	defer os.Remove(tmp)
+	if _, err := tmpFile.Write(payload); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("write routing payload failed: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
 		return fmt.Errorf("write routing payload failed: %w", err)
 	}
 	if res := sysCmd.runCombinedOutput(getPath("core", "xray", "xray"), "api", "adrules", "-s", "127.0.0.1:10085", tmp); res.Err != nil {

--- a/backend/xray_routing_dynamic_test.go
+++ b/backend/xray_routing_dynamic_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,7 +58,13 @@ func TestSyncXrayRoutingRulesDynamicallySupportsDomainWildcard(t *testing.T) {
 	if err := os.MkdirAll(xrayDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink("/bin/true", filepath.Join(xrayDir, "xray")); err != nil {
+	// The payload now goes to an unpredictable temp path that the caller removes
+	// once xray has read it, so assert on what xray was actually handed rather
+	// than on a fixed filename. This stub stands in for the binary and copies
+	// its last argument -- the payload path -- somewhere the test can read.
+	capturePath := filepath.Join(tempRoot, "routing_payload.json")
+	stub := fmt.Sprintf("#!/bin/sh\nfor last in \"$@\"; do :; done\ncp \"$last\" %q\n", capturePath)
+	if err := os.WriteFile(filepath.Join(xrayDir, "xray"), []byte(stub), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	oldHome := os.Getenv("PROXYGW_HOME")
@@ -72,7 +79,7 @@ func TestSyncXrayRoutingRulesDynamicallySupportsDomainWildcard(t *testing.T) {
 		t.Fatalf("syncXrayRoutingRulesDynamically error: %v", err)
 	}
 
-	payload, err := os.ReadFile("/tmp/proxygw_xray_routing_rules.json")
+	payload, err := os.ReadFile(capturePath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/xray_service.go
+++ b/backend/xray_service.go
@@ -471,7 +471,10 @@ func applyXrayConfigInternal(restart bool) error {
 		return fmt.Errorf("xray config validation failed, check node parameters")
 	}
 
-	if err := os.WriteFile(getPath("core", "xray", "config.json"), configData, 0644); err != nil {
+	// config.json holds every node's credentials (VLESS UUIDs, Trojan and
+	// Shadowsocks passwords). Only root reads it -- xray and this backend both
+	// run as root -- so there is no reason for it to be world-readable.
+	if err := os.WriteFile(getPath("core", "xray", "config.json"), configData, 0600); err != nil {
 		return fmt.Errorf("failed to write xray config.json: %v", err)
 	}
 	if !restart {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -177,7 +177,7 @@ PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes
 RestrictSUIDSGID=yes
-ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf -/etc/nftables.conf.proxygw.new -/etc/nftables.conf.proxygw.bak -/etc/
+ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf -/etc/nftables.conf.proxygw.new -/etc/nftables.conf.proxygw.bak
 
 [Install]
 WantedBy=multi-user.target
@@ -215,8 +215,13 @@ WorkingDirectory=/root/proxygw/core/xray
 Environment=XRAY_LOCATION_ASSET=/root/proxygw/core/xray
 ExecStart=/root/proxygw/core/xray/xray run -confdir /root/proxygw/core/xray
 Restart=on-failure
+# Xray exits 23 when it rejects its own configuration. Without this, a bad
+# config turns Restart=on-failure into an endless restart loop that floods the
+# journal instead of stopping with a diagnosable failure.
+RestartPreventExitStatus=23
 RestartSec=5
 LimitNOFILE=1048576
+LimitNPROC=10000
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -102,7 +102,7 @@ PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes
 RestrictSUIDSGID=yes
-ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf -/etc/nftables.conf.proxygw.new -/etc/nftables.conf.proxygw.bak -/etc/
+ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf -/etc/nftables.conf.proxygw.new -/etc/nftables.conf.proxygw.bak
 
 [Install]
 WantedBy=multi-user.target
@@ -140,8 +140,13 @@ WorkingDirectory=/root/proxygw/core/xray
 Environment=XRAY_LOCATION_ASSET=/root/proxygw/core/xray
 ExecStart=/root/proxygw/core/xray/xray run -confdir /root/proxygw/core/xray
 Restart=on-failure
+# Xray exits 23 when it rejects its own configuration. Without this, a bad
+# config turns Restart=on-failure into an endless restart loop that floods the
+# journal instead of stopping with a diagnosable failure.
+RestartPreventExitStatus=23
 RestartSec=5
 LimitNOFILE=1048576
+LimitNPROC=10000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## 背景

接上一个 PR（#20）。这批处理的是**本地网关侧**的服务加固，和远程节点参数无关，两者不重叠。

对照 [hello-yunshu/Xray_bash_onekey](https://github.com/hello-yunshu/Xray_bash_onekey) 在部署 Xray 时施加的安全设置 —— 它的 `apply_sensitive_file_permissions()` 默认就是 **600**，配置文件写入包在 `umask 077` + `mktemp` + 原子 mv 里，systemd unit 走 XTLS 官方那套（`User=nobody` + `CapabilityBoundingSet` + `RestartPreventExitStatus=23`）。本仓库这边 `proxygw.service` 有一整段 `# Security Sandboxing`，但 xray/mosdns 两个 unit 只有 `LimitNOFILE`，且几个 root 写出的文件是 0644。

## 改动

### 1. `core/xray/config.json` 0644 → 0600

这个文件装的是每个节点的完整凭据（VLESS UUID、Trojan / Shadowsocks 密码）。两个读者（xray 和 backend）都以 root 运行，world-readable 没有任何收益。

当前唯一的防线是 `/root` 目录本身 0700 —— 也就是说，一旦目录树挪出 `/root`（降权到非 root 用户的必经步骤），凭据立刻裸奔。

### 2. 两个 `/tmp` 固定路径 → `os.CreateTemp`

- `/tmp/proxygw_xray_outbounds.json`（0644）—— 装的是和 config.json 同一批凭据
- `/tmp/proxygw_xray_routing_rules.json`（0644）—— 无凭据，但固定路径问题相同

**关于严重性说清楚**：`proxygw.service` 设了 `PrivateTmp=yes`，所以在 systemd 下跑时这些文件对其他本地用户**不可见**，不是一个当前可利用的泄露。但这条 directive 是凭据和任意本地读者之间唯一的一道墙，而且脱离 unit 直接跑 backend（开发、调试、手动启动）时它就不生效了。固定路径另外还是一个符号链接目标 —— 低权用户预先建好，就能重定向这次 root 写入。

两处现在都改成 `os.CreateTemp`（不可预测文件名，0600）+ 用完 `os.Remove`，和 `writeXrayConfig` 里已有的配置测试临时文件写法一致。

### 3. `ReadWritePaths` 去掉结尾的 `-/etc/`

原值末尾的 `-/etc/` 授予整个 `/etc` 写权限，把 `ProtectSystem=strict` 基本作废 —— 连同它前面刚刚逐条列出的 `/etc/frr`、`/etc/nftables.conf` 也一起失去意义。

已核对 backend 在本机 `/etc` 下的全部写入：

- `/etc/frr/daemons`、`/etc/frr/frr.conf` → 已被 `-/etc/frr` 覆盖
- `/etc/nftables.conf`、`.proxygw.new`、`.proxygw.bak` → 已逐条列出
- `/etc/wireguard` → 本机只有 `os.Stat` 读取（`wireguard_service.go`），写入发生在远程节点上（`deploy_script.go` 与 SSH 命令），不经过本 unit

所以去掉这条不影响任何现有写入路径。

### 4. `RestartPreventExitStatus=23`

对齐 XTLS 官方 unit。Xray 拒绝自身配置时以 23 退出，没有这条 `Restart=on-failure` 会无限重启刷 journal，而不是停下来留一个可诊断的失败。顺带补 `LimitNPROC=10000`（官方 unit 同样有）。

## 一处更正

我先前认为"日志无轮转"是错的。[`db_maintenance.go`](../blob/main/backend/db_maintenance.go) 的 `rotateLogs()` 已经在 50MB 处截断，且 xray 日志写在 `/run/proxygw/`（tmpfs，重启即清），不落盘。所以本 PR **不包含** logrotate 改动。

（附带发现：`.gitignore` 里的 `/core/xray/access.log`、`/core/mosdns/mosdns.log` 条目和实际日志路径已经对不上，属于历史残留，未在本 PR 处理。）

## 测试

**本 PR 没有新增测试。** 三处改动都是机械性的（权限位、临时文件写法、unit 指令），且 `sysCmd` 是包级具体类型 `*commandExecutor` 而非接口，`writeXrayConfigOnly` 走不通 mock，硬造测试需要真实 xray 二进制。依赖 CI 的 `go vet` / `go build` / `go test` / `go test -race` 确认没有回归。

`scripts/` 下的两处改动没有任何自动化覆盖，需要在真机上验证一次：装完/升级完确认 `systemctl status proxygw xray` 正常、Mode B/C 下 FRR 与 nftables 配置仍能被写入。

## 未包含

- **xray/mosdns 完整 systemd 沙箱**（`CapabilityBoundingSet` / `ProtectSystem=strict` / `RestrictAddressFamilies` 等）—— 收窄能力集有真实概率打断 TProxy，必须在真机上验一轮才能合，不适合盲发。
- **降权到非 root** —— 需要先把 `core/` 从 `/root/proxygw` 挪到 `/opt` 或 `/var/lib`（`/root` 是 0700，非 root 账户读不到 config 和 geodata），连带改 install/update/uninstall/getPath 与文档，是独立的一个 PR。
- **`/etc/frr/frr.conf` 仍是 0644** —— 不能简单收紧：FRR 以 `frr` 用户运行，写成 0600 root:root 会直接让它读不到配置。正确做法是 0640 + chown 到 frr 属组，需要拿到 frr 的 uid/gid，单独处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
