### PR TITLE
ci: stop rebuilding the backend on merge to main

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,11 +5,7 @@ on:
     paths:
       - 'backend/**'
       - '.github/workflows/backend-ci.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'backend/**'
-      - '.github/workflows/backend-ci.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## 改动

`backend-ci.yml` 原本同时挂在 `pull_request` 和 `push: branches: [main]` 上，所以每次合并都会把刚刚在 PR 上验证过的同一份代码重新编译、重新跑一遍测试。

去掉 `push` 触发。验证留在它真正影响决策的地方 —— 合并之前的 PR 上。

## 澄清一点

后端二进制的产出**本来就只发生在发布时**：[`release.yml`](../blob/main/.github/workflows/release.yml) 由 `v*` tag 触发，交叉编译 amd64/arm64 并 attach 到 release。`backend-ci.yml` 里的 `go build ./...` 是验证性编译，不产出任何制品。本 PR 不改变这一点。

## 保留

- `pull_request` —— PR 阶段仍然跑 `go vet` / `go build` / `go test` / `go test -race`
- 新增 `workflow_dispatch` —— 需要时可以手动对某个分支跑一遍

## 触发时机对照

| 时机 | 改动前 | 改动后 |
|---|---|---|
| 开 / 更新 PR | 跑 | 跑 |
| 合并到 main | 跑 | 不跑 |
| 打 `v*` tag | release.yml 交叉编译 | 不变 |
| 手动 | 无 | `workflow_dispatch` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
