### PR TITLE
security: fix login rate-limit bypass and unverified mosdns installs

### DIFF
--- a/backend/app_controller.go
+++ b/backend/app_controller.go
@@ -27,6 +27,15 @@ func NewAppController() *AppController {
 
 func (c *AppController) BuildRouter() *gin.Engine {
 	r := gin.Default()
+	// gin trusts every peer as a proxy by default (trustedCIDRs = 0.0.0.0/0 and
+	// ::/0) and reads the client address out of X-Forwarded-For / X-Real-IP.
+	// On a gateway that listens directly on the LAN that makes c.ClientIP()
+	// fully caller-controlled: it forged the source IP recorded in security
+	// events and handed anyone a fresh login rate-limit bucket per request.
+	// Nothing fronts this server, so trust no proxy and read the peer address.
+	if err := r.SetTrustedProxies(nil); err != nil {
+		log.Printf("[SECURITY] failed to clear trusted proxies: %v", err)
+	}
 	registerAPIRoutes(r)
 	r.Use(func(c *gin.Context) {
 		if strings.HasPrefix(c.Request.URL.Path, "/ui") {
@@ -51,13 +60,6 @@ func (c *AppController) Run(r *gin.Engine) {
 	r.Run(addr)
 }
 
-func getLogWriter() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
-		c.Writer.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
-		c.Next()
-	}
-}
 
 func init() {
 	os.Setenv("TZ", "Asia/Shanghai")

--- a/backend/auth_controller.go
+++ b/backend/auth_controller.go
@@ -13,17 +13,40 @@ type AuthController struct{}
 
 func NewAuthController() *AuthController { return &AuthController{} }
 
+// loginAttemptWindow is how long a failed-attempt counter survives without
+// further attempts from the same address.
+const loginAttemptWindow = 30 * time.Minute
+
+// pruneLoginAttemptsLocked drops counters that have aged out of the window.
+// Entries were previously removed only on a successful login, so every distinct
+// source address left one behind permanently. Callers must hold
+// loginAttemptsMu.
+func pruneLoginAttemptsLocked(now time.Time) {
+	for addr, data := range loginAttempts {
+		if now.Sub(data.LastSeen) > loginAttemptWindow {
+			delete(loginAttempts, addr)
+		}
+	}
+}
+
 func (ctl *AuthController) Login(c *gin.Context) {
-	ip := c.ClientIP()
+	// Deliberately RemoteIP(), not ClientIP(): the brute-force counter must key
+	// on the address the packets actually came from. ClientIP() consults
+	// X-Forwarded-For, so a caller could hand itself an unused bucket on every
+	// request and never reach the delay or the lockout below. SetTrustedProxies
+	// in BuildRouter already makes the two equivalent today; this keeps the
+	// limiter correct even if a proxy is configured later.
+	ip := c.RemoteIP()
 	now := time.Now()
 
 	loginAttemptsMu.Lock()
+	pruneLoginAttemptsLocked(now)
 	attemptData, ok := loginAttempts[ip]
 	if !ok {
 		attemptData = &LoginAttempt{Count: 0, LastSeen: now}
 		loginAttempts[ip] = attemptData
 	}
-	if now.Sub(attemptData.LastSeen) > 30*time.Minute {
+	if now.Sub(attemptData.LastSeen) > loginAttemptWindow {
 		attemptData.Count = 0
 	}
 

--- a/backend/auth_ratelimit_test.go
+++ b/backend/auth_ratelimit_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// loginRequest builds an unauthenticated POST /api/login carrying a wrong
+// password and, optionally, a forged X-Forwarded-For.
+func loginRequest(forwardedFor string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(`{"Password":"wrong-password"}`))
+	req.Header.Set("Content-Type", "application/json")
+	if forwardedFor != "" {
+		req.Header.Set("X-Forwarded-For", forwardedFor)
+	}
+	return req
+}
+
+func TestLoginRateLimitIgnoresForwardedForHeader(t *testing.T) {
+	r := setupFeatureSuiteRouter(t)
+
+	// Every request arrives from the same peer but claims a different client
+	// address. Keying the counter off that header would hand each request an
+	// unused bucket, so neither the delay nor the lockout would ever trigger.
+	forged := []string{
+		"203.0.113.1", "203.0.113.2", "203.0.113.3",
+		"198.51.100.7", "198.51.100.8", "10.9.9.9",
+	}
+	for _, ff := range forged {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, loginRequest(ff))
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("X-Forwarded-For %s: want 401 got %d body=%s", ff, w.Code, w.Body.String())
+		}
+	}
+
+	loginAttemptsMu.Lock()
+	defer loginAttemptsMu.Unlock()
+	if len(loginAttempts) != 1 {
+		keys := make([]string, 0, len(loginAttempts))
+		for k := range loginAttempts {
+			keys = append(keys, k)
+		}
+		t.Fatalf("forged headers created %d buckets (%v), want 1 keyed on the peer", len(loginAttempts), keys)
+	}
+	for _, data := range loginAttempts {
+		if data.Count != len(forged) {
+			t.Errorf("attempt count = %d, want %d: the failures must accumulate in one bucket", data.Count, len(forged))
+		}
+	}
+}
+
+func TestLoginRateLimitPrunesStaleBuckets(t *testing.T) {
+	r := setupFeatureSuiteRouter(t)
+
+	loginAttemptsMu.Lock()
+	loginAttempts["203.0.113.55"] = &LoginAttempt{Count: 9, LastSeen: time.Now().Add(-loginAttemptWindow - time.Minute)}
+	loginAttempts["203.0.113.56"] = &LoginAttempt{Count: 3, LastSeen: time.Now().Add(-2 * loginAttemptWindow)}
+	loginAttemptsMu.Unlock()
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, loginRequest(""))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 got %d", w.Code)
+	}
+
+	// Buckets used to be removed only on a successful login, so a failed-login
+	// flood left one entry per source address behind forever.
+	loginAttemptsMu.Lock()
+	defer loginAttemptsMu.Unlock()
+	for _, stale := range []string{"203.0.113.55", "203.0.113.56"} {
+		if _, ok := loginAttempts[stale]; ok {
+			t.Errorf("stale bucket %s survived the prune", stale)
+		}
+	}
+}
+
+func TestLoginRateLimitLocksOutAfterRepeatedFailures(t *testing.T) {
+	r := setupFeatureSuiteRouter(t)
+
+	// Seed the bucket for this peer just below the lockout so the test does not
+	// have to sit through the 2s delay applied to attempts 7 through 10.
+	req := loginRequest("")
+	peer, _, _ := strings.Cut(req.RemoteAddr, ":")
+	loginAttemptsMu.Lock()
+	loginAttempts[peer] = &LoginAttempt{Count: 11, LastSeen: time.Now()}
+	loginAttemptsMu.Unlock()
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("want 429 after exceeding the attempt ceiling, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestBuildRouterDoesNotTrustForwardedFor(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+
+	r := NewAppController().BuildRouter()
+	var seen string
+	r.GET("/__clientip_probe", func(c *gin.Context) {
+		seen = c.ClientIP()
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/__clientip_probe", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.99")
+	req.Header.Set("X-Real-IP", "203.0.113.98")
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	// gin trusts every peer as a proxy unless told otherwise, which would make
+	// ClientIP() return the forged header and put a caller-controlled value into
+	// the source_ip column of every security event.
+	peer, _, _ := strings.Cut(req.RemoteAddr, ":")
+	if seen != peer {
+		t.Errorf("ClientIP() = %q, want the peer address %q: forwarding headers must not be trusted", seen, peer)
+	}
+}

--- a/backend/helpers.go
+++ b/backend/helpers.go
@@ -15,17 +15,39 @@ import (
 	"time"
 )
 
+// releaseVersionRe constrains a release tag to a single path segment. Anything
+// with a slash, a dot segment or a query/fragment character could retarget a
+// download URL at a different repository, so tags that do not match are
+// rejected before they are interpolated into one.
+var releaseVersionRe = regexp.MustCompile(`^v[0-9A-Za-z._-]+$`)
+
+// xrayAssetName returns the Xray release asset for the running architecture.
+// Hardcoding the amd64 asset meant an in-app update on an arm64 gateway
+// replaced a working binary with one the machine cannot execute.
+func xrayAssetName() (string, error) {
+	switch runtime.GOARCH {
+	case "amd64":
+		return "Xray-linux-64.zip", nil
+	case "arm64":
+		return "Xray-linux-arm64-v8a.zip", nil
+	default:
+		return "", fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+	}
+}
+
 func buildXrayDownloadURL(version string) (string, error) {
-	base := "https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-64.zip"
+	asset, err := xrayAssetName()
+	if err != nil {
+		return "", err
+	}
 	ver := strings.TrimSpace(version)
 	if ver == "" || ver == "latest" {
-		return base, nil
+		return "https://github.com/XTLS/Xray-core/releases/latest/download/" + asset, nil
 	}
-	matched, _ := regexp.MatchString(`^v[0-9A-Za-z._-]+$`, ver)
-	if !matched {
+	if !releaseVersionRe.MatchString(ver) {
 		return "", fmt.Errorf("invalid version")
 	}
-	return fmt.Sprintf("https://github.com/XTLS/Xray-core/releases/download/%s/Xray-linux-64.zip", ver), nil
+	return fmt.Sprintf("https://github.com/XTLS/Xray-core/releases/download/%s/%s", ver, asset), nil
 }
 
 func parseXrayVersionOutput(output string) string {
@@ -164,7 +186,60 @@ func getXrayHash(version string) (string, error) {
 	return "", fmt.Errorf("hash not found in dgst")
 }
 
+// getMosdnsHash returns the SHA-256 of the mosdns release asset for the running
+// architecture, taken from the digest GitHub publishes for it.
+//
+// Unlike Xray, mosdns ships no .dgst (or any other checksum) alongside its
+// release assets, so there is no upstream file to read. The releases API
+// reports a "digest" field per asset instead. It is fail-closed: a release
+// without a usable digest yields an error rather than an unverified install.
+func getMosdnsHash(version string) (string, error) {
+	arch, err := mosdnsArch()
+	if err != nil {
+		return "", err
+	}
+	ver := strings.TrimSpace(version)
+	if ver == "" || ver == "latest" {
+		return "", fmt.Errorf("explicit version required for mosdns")
+	}
+	if !releaseVersionRe.MatchString(ver) {
+		return "", fmt.Errorf("invalid version")
+	}
+	content, err := getRemoteFileContent("https://api.github.com/repos/IrineSistiana/mosdns/releases/tags/" + ver)
+	if err != nil {
+		return "", err
+	}
+	var release struct {
+		Assets []struct {
+			Name   string `json:"name"`
+			Digest string `json:"digest"`
+		} `json:"assets"`
+	}
+	if err := json.Unmarshal([]byte(content), &release); err != nil {
+		return "", fmt.Errorf("parse mosdns release failed: %w", err)
+	}
+	want := mosdnsAssetName(arch)
+	for _, a := range release.Assets {
+		if a.Name != want {
+			continue
+		}
+		hash := strings.TrimPrefix(a.Digest, "sha256:")
+		if hash == a.Digest || hash == "" {
+			return "", fmt.Errorf("mosdns asset %s has no sha256 digest", want)
+		}
+		return hash, nil
+	}
+	return "", fmt.Errorf("mosdns asset %s not found in release %s", want, ver)
+}
+
 func downloadWithVerification(urlStr, dest, expectedHash string) error {
+	// Fail closed. This used to skip verification whenever expectedHash was
+	// empty, and the mosdns update path passed "" -- so an unverified archive
+	// was unzipped and installed as a binary that runs as root. A caller with
+	// no hash to check against has no business using this function.
+	if strings.TrimSpace(expectedHash) == "" {
+		return fmt.Errorf("refusing to install %s without an expected sha256", urlStr)
+	}
 	resp, err := downloadClient.Get(urlStr)
 	if err != nil {
 		return err
@@ -186,11 +261,9 @@ func downloadWithVerification(urlStr, dest, expectedHash string) error {
 		return err
 	}
 
-	if expectedHash != "" {
-		if err := verifySHA256(tmpPath, expectedHash); err != nil {
-			os.Remove(tmpPath)
-			return err
-		}
+	if err := verifySHA256(tmpPath, expectedHash); err != nil {
+		os.Remove(tmpPath)
+		return err
 	}
 
 	return os.Rename(tmpPath, dest)
@@ -201,18 +274,33 @@ var httpClient = &http.Client{
 	Timeout: 15 * time.Second,
 }
 
-func buildMosdnsDownloadURL(version string) (string, error) {
+func mosdnsArch() (string, error) {
 	arch := runtime.GOARCH
 	if arch != "arm64" && arch != "amd64" {
 		return "", fmt.Errorf("unsupported architecture: %s", arch)
+	}
+	return arch, nil
+}
+
+func buildMosdnsDownloadURL(version string) (string, error) {
+	arch, err := mosdnsArch()
+	if err != nil {
+		return "", err
 	}
 
 	ver := strings.TrimSpace(version)
 	if ver == "" || ver == "latest" {
 		return "", fmt.Errorf("explicit version required for mosdns")
 	}
+	if !releaseVersionRe.MatchString(ver) {
+		return "", fmt.Errorf("invalid version")
+	}
 
-	return fmt.Sprintf("https://github.com/IrineSistiana/mosdns/releases/download/%s/mosdns-linux-%s.zip", ver, arch), nil
+	return fmt.Sprintf("https://github.com/IrineSistiana/mosdns/releases/download/%s/%s", ver, mosdnsAssetName(arch)), nil
+}
+
+func mosdnsAssetName(arch string) string {
+	return fmt.Sprintf("mosdns-linux-%s.zip", arch)
 }
 
 func formatBytes(b int64) string {

--- a/backend/helpers_download_test.go
+++ b/backend/helpers_download_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildXrayDownloadURLMatchesRunningArchitecture(t *testing.T) {
+	wantAsset, err := xrayAssetName()
+	if err != nil {
+		t.Skipf("architecture %s is not a release target", runtime.GOARCH)
+	}
+
+	// The asset used to be hardcoded to Xray-linux-64.zip, so an in-app update
+	// on an arm64 gateway installed a binary the machine cannot execute.
+	latest, err := buildXrayDownloadURL("latest")
+	if err != nil {
+		t.Fatalf("buildXrayDownloadURL(latest) error: %v", err)
+	}
+	if !strings.HasSuffix(latest, "/"+wantAsset) {
+		t.Errorf("latest URL = %s, want it to end in %s", latest, wantAsset)
+	}
+
+	pinned, err := buildXrayDownloadURL("v1.8.24")
+	if err != nil {
+		t.Fatalf("buildXrayDownloadURL(v1.8.24) error: %v", err)
+	}
+	if !strings.HasSuffix(pinned, "/"+wantAsset) {
+		t.Errorf("pinned URL = %s, want it to end in %s", pinned, wantAsset)
+	}
+	if !strings.Contains(pinned, "/download/v1.8.24/") {
+		t.Errorf("pinned URL = %s, want the requested tag in the path", pinned)
+	}
+}
+
+// badVersions are tags that must never be interpolated into a download URL:
+// each could retarget it at another path or another repository.
+var badVersions = []string{
+	"v1/../../../../attacker/evil/releases/download/v1",
+	"../../attacker/evil",
+	"v1.0.0/../../..",
+	"v1 v2",
+	"v1\nv2",
+	"v1?x=y",
+	"v1#frag",
+	"v1@evil.com",
+	"https://evil.example.com/x",
+	"latest/../..",
+}
+
+func TestBuildXrayDownloadURLRejectsMalformedVersions(t *testing.T) {
+	if _, err := xrayAssetName(); err != nil {
+		t.Skipf("architecture %s is not a release target", runtime.GOARCH)
+	}
+	for _, v := range badVersions {
+		if url, err := buildXrayDownloadURL(v); err == nil {
+			t.Errorf("buildXrayDownloadURL(%q) = %s, want error", v, url)
+		}
+	}
+}
+
+func TestBuildMosdnsDownloadURLRejectsMalformedVersions(t *testing.T) {
+	arch, err := mosdnsArch()
+	if err != nil {
+		t.Skipf("architecture %s is not a release target", runtime.GOARCH)
+	}
+
+	// This builder had no validation at all, unlike its Xray counterpart.
+	for _, v := range badVersions {
+		if url, err := buildMosdnsDownloadURL(v); err == nil {
+			t.Errorf("buildMosdnsDownloadURL(%q) = %s, want error", v, url)
+		}
+	}
+	for _, v := range []string{"", "   ", "latest"} {
+		if url, err := buildMosdnsDownloadURL(v); err == nil {
+			t.Errorf("buildMosdnsDownloadURL(%q) = %s, want error", v, url)
+		}
+	}
+
+	good, err := buildMosdnsDownloadURL("v5.3.4")
+	if err != nil {
+		t.Fatalf("buildMosdnsDownloadURL(v5.3.4) error: %v", err)
+	}
+	want := "https://github.com/IrineSistiana/mosdns/releases/download/v5.3.4/mosdns-linux-" + arch + ".zip"
+	if good != want {
+		t.Errorf("buildMosdnsDownloadURL(v5.3.4) = %s, want %s", good, want)
+	}
+}
+
+func TestGetMosdnsHashRejectsMalformedVersionsWithoutNetwork(t *testing.T) {
+	if _, err := mosdnsArch(); err != nil {
+		t.Skipf("architecture %s is not a release target", runtime.GOARCH)
+	}
+	// Validation must happen before the release lookup, so these never reach
+	// the network even when it is unavailable.
+	for _, v := range append(append([]string{}, badVersions...), "", "latest") {
+		if hash, err := getMosdnsHash(v); err == nil {
+			t.Errorf("getMosdnsHash(%q) = %s, want error", v, hash)
+		}
+	}
+}
+
+func TestDownloadWithVerificationRejectsBlankExpectedHash(t *testing.T) {
+	// The mosdns update path passed "" here, which took the fail-open branch and
+	// installed whatever came back over the wire as a root-run binary.
+	if err := downloadWithVerification("https://example.invalid/x.zip", t.TempDir()+"/x.zip", ""); err == nil {
+		t.Error("downloadWithVerification with a blank hash = nil, want error")
+	}
+}

--- a/backend/update_controller.go
+++ b/backend/update_controller.go
@@ -103,6 +103,11 @@ func (ctl *UpdateController) UpdateComponent(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid version"})
 			return
 		}
+		mosdnsHash, err := getMosdnsHash(req.Version)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "failed to fetch hash"})
+			return
+		}
 
 		if err := sysCmd.run("cp", getPath("core", "mosdns", "mosdns"), getPath("core", "mosdns", "mosdns.bak")); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "backup failed"})
@@ -117,7 +122,7 @@ func (ctl *UpdateController) UpdateComponent(c *gin.Context) {
 		defer os.RemoveAll(tmpDir)
 		mosdnsZip := filepath.Join(tmpDir, "mosdns.zip")
 
-		if err := downloadWithVerification(downloadURL, mosdnsZip, ""); err != nil {
+		if err := downloadWithVerification(downloadURL, mosdnsZip, mosdnsHash); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": fmt.Sprintf("mosdns download failed: %v", err)})
 			return
 		}


### PR DESCRIPTION
## 背景

前几个 PR 处理的是部署脚本和远程节点。这个 PR 是 Web 后端本身 —— 管理面板默认监听 `:80` 全接口，install.sh 生成的 nftables 没有 input 链，所以下面这些都是从局域网可达的。

## 1. 防爆破可被一个 HTTP 头完全绕过

限流计数器键在 `c.ClientIP()` 上。而 gin 1.12.0 的默认配置是：

```go
ForwardedByClientIP: true,
RemoteIPHeaders:     []string{"X-Forwarded-For", "X-Real-IP"},
trustedCIDRs:        defaultTrustedCIDRs,   // 0.0.0.0/0 + ::/0
```

`defaultTrustedCIDRs` 覆盖全部地址空间，`isTrustedProxy()` 恒为 true，而本仓库从未调用过 `SetTrustedProxies`。于是 `ClientIP()` 返回的就是调用方自己填的请求头。

每次请求换一个 `X-Forwarded-For`，`loginAttempts[ip]` 就是全新条目、`Count = 0`：

- `Count > 5` 的 2 秒延时 —— 永不触发
- `Count > 10` 的 429 锁定 —— 永不触发

对网关管理密码的在线爆破没有任何速率限制。README 里"前端自带防爆破延时"这条实际不成立。

同一个伪造值还会被写进每条网关事件的 `source_ip`（`event_logs.go`、`system_service.go` 两处），也就是审计日志的来源 IP 可任意伪造。

**修法**：`BuildRouter()` 里 `SetTrustedProxies(nil)`，让 `ClientIP()` 回落到真实对端；限流键额外显式改用 `RemoteIP()` —— 这样即使将来有人配了反代信任列表，爆破计数器仍然锚在真实对端上。

另外 attempt bucket 原本只在**登录成功**时 `delete`，失败洪水会给每个来源地址永久留一个条目。现在按 30 分钟窗口过期清理。

## 2. mosdns 更新完全不校验就安装

```go
downloadWithVerification(downloadURL, mosdnsZip, "")   // 空 hash
```

`downloadWithVerification` 里是 `if expectedHash != ""` —— 空字符串走 fail-open 分支跳过校验。下载完 `unzip` + `install -m 755` 直接覆盖以 root 运行的 mosdns 二进制。

这不是设计缺失，是漏了一处：

| 调用点 | 传入 | 校验 |
|---|---|---|
| geodata (`update_routes.go`) | `hashZip` | ✅ |
| Xray (`update_controller.go`) | `getXrayHash()` | ✅ |
| mosdns (`update_controller.go`) | `""` | ❌ |

**修法**：mosdns 上游不发布任何校验文件（我查了 releases，只有 .zip 资产，没有 .dgst / .sha256），所以取 GitHub releases API 为每个资产给出的 `digest` 字段。新增 `getMosdnsHash()`，fail-closed —— 拿不到 digest 就报错，不装。

同时把 `downloadWithVerification` 本身改成**空 hash 直接拒绝**，这样今后任何调用方都无法再意外跳过校验。三个调用点现在都传真 hash，改动安全。

## 3. `buildMosdnsDownloadURL` 对 version 零校验

`ver` 只做 `TrimSpace` 和非空判断就拼进 URL。而姊妹函数 `buildXrayDownloadURL` 有 `^v[0-9A-Za-z._-]+$` 正则 —— 一个有一个没有，明显是漏写。和第 2 条叠加，就是"装哪个二进制"的两道关卡同时缺失。

现在两者共用同一个 `releaseVersionRe`。

（能否真的把路径拼到别的仓库，取决于 GitHub 对 `..` 路径段的处理，我没有实测。但输入本来就该在源头约束，这条不依赖利用链是否成立。）

## 4. 顺带：Xray 更新硬编码 amd64

`buildXrayDownloadURL` 里 base 和格式化串都写死 `Xray-linux-64.zip`，没有 `runtime.GOARCH` 分支（隔壁 mosdns 那个有）。在 ARM64 网关上点"更新 Xray"，会把可用的 arm64 二进制换成 amd64 的，xray 直接起不来。install.sh 那边是正确处理了的。

新增 `xrayAssetName()`，按架构返回 `Xray-linux-64.zip` / `Xray-linux-arm64-v8a.zip`，不支持的架构报错。

## 5. 删除死代码 `getLogWriter`

定义在 `app_controller.go`，设置 `Access-Control-Allow-Origin: *` 和 `Access-Control-Allow-Headers: Authorization` —— 但 `BuildRouter()` 从未注册它，全仓库 grep 只有定义处一个匹配。实际上一个 CORS 头都不发。删掉，免得日后有人误以为它在生效。

## 测试

- `auth_ratelimit_test.go` —— 6 个不同 `X-Forwarded-For` 的失败登录必须落进**同一个** bucket 且计数累加到 6；过期 bucket 被清理；超限返回 429；`BuildRouter()` 产出的引擎对带伪造头的请求，`ClientIP()` 返回真实对端。
- `helpers_download_test.go` —— 两个 URL 构造函数都必须拒绝一组畸形 version（路径穿越、空白、换行、`?`/`#`/`@`、完整 URL）；Xray URL 跟随运行架构；`getMosdnsHash` 在畸形 version 上先于网络请求报错；`downloadWithVerification` 拒绝空 hash。

## 查过没问题的（记录在案，避免重复审）

- **没有命令注入面** —— `commandExecutor` 全程 `exec.Command(name, args...)` 不经 shell；全仓库唯一的 `sh -c` 是固定字符串
- **鉴权边界干净** —— 只有 `/login` 未鉴权，其余全在 `authed` 组
- bcrypt + 128 位随机 session token + 滑动过期；认证走 Authorization header 而非 cookie，天然免疫 CSRF
- 应用内更新器有备份 + 失败回滚
- e2e token bypass 有 env 开关且默认关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)
