### PR TITLE
fix(scripts): stop unbounded DB backups and leaving the gateway stopped

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,6 +17,17 @@ export GOPROXY="${GOPROXY:-https://goproxy.cn,direct}"
 cd "$BACKEND_DIR"
 go build -o proxygw-backend .
 
-echo "Build successful. Restarting service..."
-systemctl restart proxygw
-echo "Service restarted."
+echo "Build successful: $BACKEND_DIR/proxygw-backend"
+
+# Deploying is a separate decision from building. This used to restart proxygw
+# unconditionally, so compiling on the gateway dropped every active connection
+# whether or not that was the intent.
+if [ "${PROXYGW_RESTART_AFTER_BUILD:-0}" = "1" ]; then
+    echo "PROXYGW_RESTART_AFTER_BUILD=1, restarting service..."
+    systemctl restart proxygw
+    echo "Service restarted."
+else
+    echo "Not restarting proxygw. To deploy this build:"
+    echo "  systemctl restart proxygw"
+    echo "  (or re-run with PROXYGW_RESTART_AFTER_BUILD=1)"
+fi

--- a/scripts/db_optimize.sh
+++ b/scripts/db_optimize.sh
@@ -2,29 +2,66 @@
 set -euo pipefail
 
 DB_PATH="${1:-/root/proxygw/config/proxygw.db}"
-MODE="${2:---full}" # --index-only | --full
+# Default to the safe mode. --full takes a VACUUM, which holds a write lock for
+# the whole run; on a live gateway that stalls every DNS resolve and OSPF push
+# behind it. Taking the disruptive path must be an explicit request.
+MODE="${2:---index-only}" # --index-only | --full
+
+case "$MODE" in
+  --index-only|--full) ;;
+  *)
+    echo "[ERROR] Unknown mode: $MODE (expected --index-only or --full)" >&2
+    exit 1
+    ;;
+esac
 
 if [[ ! -f "$DB_PATH" ]]; then
   echo "[ERROR] DB not found: $DB_PATH" >&2
   exit 1
 fi
 
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "[ERROR] sqlite3 not found in PATH" >&2
+  exit 1
+fi
+
+# How many timestamped backups to keep. install.sh and update.sh run this on
+# every deploy, so an unpruned backup per run left a full copy of the database
+# behind each time -- on a long-lived gateway proxygw.db reaches hundreds of MB
+# and the copies were never reclaimed.
+BACKUP_KEEP="${DB_OPTIMIZE_BACKUP_KEEP:-3}"
+
 TS="$(date +%Y%m%d_%H%M%S)"
 BACKUP="${DB_PATH}.bak.${TS}"
+
+prune_old_backups() {
+  local keep="$1"
+  local victims
+  # Newest first; everything past the keep count goes.
+  victims=$(ls -1t "${DB_PATH}".bak.* 2>/dev/null | tail -n +"$((keep + 1))" || true)
+  if [[ -n "$victims" ]]; then
+    while IFS= read -r old; do
+      [[ -n "$old" ]] || continue
+      echo "[INFO] Removing old backup: $old"
+      rm -f "$old"
+    done <<< "$victims"
+  fi
+}
 
 echo "[INFO] DB: $DB_PATH"
 echo "[INFO] Mode: $MODE"
 
-echo "\n[STEP] Before snapshot"
+printf '\n[STEP] Before snapshot\n'
 stat -c '%n %s bytes' "$DB_PATH"
 sqlite3 "$DB_PATH" "PRAGMA page_size; PRAGMA page_count; PRAGMA freelist_count; PRAGMA journal_mode; PRAGMA synchronous; PRAGMA auto_vacuum;" \
   | awk 'NR==1{print "page_size=" $1} NR==2{print "page_count=" $1} NR==3{print "freelist_count=" $1} NR==4{print "journal_mode=" $1} NR==5{print "synchronous=" $1} NR==6{print "auto_vacuum=" $1}'
 
-echo "\n[STEP] Backup"
+printf '\n[STEP] Backup\n'
 cp -a "$DB_PATH" "$BACKUP"
 stat -c '%n %s bytes' "$BACKUP"
+prune_old_backups "$BACKUP_KEEP"
 
-echo "\n[STEP] Create/refresh indexes"
+printf '\n[STEP] Create/refresh indexes\n'
 sqlite3 "$DB_PATH" <<'SQL'
 CREATE INDEX IF NOT EXISTS idx_dgl_domain_resolver_ver
 ON domain_geoip_lock(domain, resolver_group, geodata_ver);
@@ -37,18 +74,18 @@ PRAGMA optimize;
 SQL
 
 if [[ "$MODE" == "--full" ]]; then
-  echo "\n[STEP] VACUUM (may take time and hold write lock)"
+  printf '\n[STEP] VACUUM (may take time and hold write lock)\n'
   sqlite3 "$DB_PATH" "VACUUM;"
   sqlite3 "$DB_PATH" "ANALYZE; PRAGMA optimize;"
 fi
 
-echo "\n[STEP] After snapshot"
+printf '\n[STEP] After snapshot\n'
 stat -c '%n %s bytes' "$DB_PATH"
 sqlite3 "$DB_PATH" "PRAGMA page_size; PRAGMA page_count; PRAGMA freelist_count; PRAGMA journal_mode; PRAGMA synchronous; PRAGMA auto_vacuum;" \
   | awk 'NR==1{print "page_size=" $1} NR==2{print "page_count=" $1} NR==3{print "freelist_count=" $1} NR==4{print "journal_mode=" $1} NR==5{print "synchronous=" $1} NR==6{print "auto_vacuum=" $1}'
 
-echo "\n[STEP] Query plan check"
+printf '\n[STEP] Query plan check\n'
 sqlite3 "$DB_PATH" "EXPLAIN QUERY PLAN SELECT geoip_tag FROM domain_geoip_lock WHERE domain='example.com' AND resolver_group='direct' AND geodata_ver='v1';"
 sqlite3 "$DB_PATH" "EXPLAIN QUERY PLAN SELECT id,module,level,ts FROM gateway_events WHERE module='ospf' AND level='info' ORDER BY id DESC LIMIT 50;"
 
-echo "\n[DONE] Backup: $BACKUP"
+printf '\n[DONE] Backup: %s\n' "$BACKUP"

--- a/scripts/flush_cache.sh
+++ b/scripts/flush_cache.sh
@@ -1,19 +1,51 @@
 #!/bin/bash
-set -e
+# flush_cache.sh — clear legacy/dirty DNS cache and OSPF routes.
+set -euo pipefail
+
+DB_PATH="${1:-/root/proxygw/config/proxygw.db}"
 
 echo "========================================================="
 echo "  EdgeRouteGW / ProxyGW Cache Flush Utility"
 echo "  This will clear legacy/dirty DNS cache and OSPF routes."
+echo "  Database: $DB_PATH"
 echo "========================================================="
+
+# Every precondition is checked before the service is touched. This used to stop
+# proxygw first and only then look for the database, so running it against a
+# non-default install left the gateway stopped and offline while reporting
+# nothing worse than "database not found".
+if [ ! -f "$DB_PATH" ]; then
+    echo "Error: Database not found at $DB_PATH" >&2
+    echo "Pass the database path as the first argument for non-default installs." >&2
+    exit 1
+fi
+if ! command -v sqlite3 >/dev/null 2>&1; then
+    echo "Error: sqlite3 not found in PATH" >&2
+    exit 1
+fi
+
+if [ -t 0 ]; then
+    read -r -p "This deletes cached DNS results, OSPF routes and geosite expansions. Continue? [y/N]: " answer
+    case "$answer" in
+        [Yy]*) ;;
+        *) echo "Aborted."; exit 0 ;;
+    esac
+fi
+
+# From here on the service is down, so any early exit must bring it back up
+# rather than leave the gateway offline.
+service_stopped=0
+restore_service() {
+    if [ "$service_stopped" -eq 1 ]; then
+        echo "Restarting proxygw service..."
+        systemctl start proxygw || echo "Warning: failed to restart proxygw -- start it manually." >&2
+    fi
+}
+trap restore_service EXIT
 
 echo "[1/4] Stopping proxygw service to prevent DB locks..."
 systemctl stop proxygw
-
-DB_PATH="/root/proxygw/config/proxygw.db"
-if [ ! -f "$DB_PATH" ]; then
-    echo "Error: Database not found at $DB_PATH"
-    exit 1
-fi
+service_stopped=1
 
 echo "[2/4] Deleting DNS resolve cache (domain_resolve_cache)..."
 sqlite3 "$DB_PATH" "DELETE FROM domain_resolve_cache;"
@@ -23,9 +55,6 @@ sqlite3 "$DB_PATH" "DELETE FROM routes_table;"
 
 echo "[4/4] Deleting Geosite expand cache (geosite_expand_cache)..."
 sqlite3 "$DB_PATH" "DELETE FROM geosite_expand_cache;"
-
-echo "Restarting proxygw service to trigger a clean OSPF push..."
-systemctl start proxygw
 
 echo "========================================================="
 echo "Done! The system will now safely re-resolve rules via SOCKS5."

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -16,16 +16,20 @@ if ! (cd backend && go build -o /dev/null .); then
 fi
 echo "  ✓ Build OK"
 
-# Run only changed package tests (fast)
-echo "  → Running affected backend tests..."
+# Run the backend tests when any Go file is staged. This previously derived a
+# list of changed packages, used it only as an "is anything staged" flag, and
+# then ran the whole suite anyway -- while discarding stderr, so a failure
+# printed "Tests failed" with no indication of which test or why.
+echo "  → Running backend tests..."
 cd "$ROOT_DIR/backend"
-CHANGED=$(git diff --cached --name-only -- '*.go' | sed 's/backend\///' | xargs -I{} dirname {} | sort -u | tr '\n' ' ')
-if [[ -n "$CHANGED" ]]; then
-  if ! go test -count=1 -short ./... 2>/dev/null; then
+if git diff --cached --name-only -- '*.go' | grep -q .; then
+  if ! go test -count=1 -short ./...; then
     echo "❌ Tests failed — fix before committing"
     exit 1
   fi
+  echo "  ✓ Tests passed"
+else
+  echo "  · No Go files staged, skipping tests"
 fi
-echo "  ✓ Tests passed"
 
 echo "=== ✓ Pre-commit checks passed ==="

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -60,7 +60,10 @@ fi
 # [5/6] Build verification
 # ──────────────────────────────────────────────
 header "Build Verification"
-if go build -o /dev/null ./backend/... 2>/dev/null; then
+# backend is its own module (module proxygw) and the repo root has no go.mod, so
+# building ./backend/... from here always failed -- and the redirect hid the
+# reason, leaving the whole suite permanently reporting failure.
+if (cd "$ROOT_DIR/backend" && go build -o /dev/null ./...); then
   green "✓ Backend builds successfully"
 else
   red "✗ Build FAILED"

--- a/scripts/test_backend.sh
+++ b/scripts/test_backend.sh
@@ -51,11 +51,7 @@ if $SHORT; then
   ARGS+=("-short")
 fi
 
-# Run with progress dots for CI
-if [[ -t 1 ]]; then
-  # Interactive terminal — use -v
-  ARGS+=("-count=1")
-fi
-
-echo "Running: go test ${ARGS[*]} ${PACKAGES[*]}"
+# -count=1 disables the test result cache; it is passed unconditionally below.
+# An interactive branch used to append it a second time, which did nothing.
+echo "Running: go test -count=1 ${ARGS[*]} ${PACKAGES[*]}"
 go test -count=1 "${ARGS[@]}" "${PACKAGES[@]}"

--- a/scripts/test_frontend.sh
+++ b/scripts/test_frontend.sh
@@ -22,10 +22,16 @@ if [[ ! -d node_modules ]]; then
   npm ci --no-fund --no-audit
 fi
 
-# Install Playwright browsers if missing
-if ! npx playwright install --with-deps --dry-run 2>/dev/null | grep -q "already installed"; then
-  echo "Installing Playwright browsers..."
+# Install Playwright browsers if missing.
+# The previous check grepped --dry-run output for "already installed", a string
+# it makes no promise of emitting, so chromium was re-downloaded on nearly every
+# run. Ask Playwright to resolve the browser instead: it exits non-zero when the
+# executable is absent, and installing is a no-op when it is already present.
+if ! npx playwright install chromium --dry-run >/dev/null 2>&1; then
+  echo "Installing Playwright browsers (with system dependencies)..."
   npx playwright install --with-deps chromium
+else
+  npx playwright install chromium >/dev/null 2>&1 || true
 fi
 
 echo "=== Running Frontend Button E2E Tests ==="


### PR DESCRIPTION
## P0

### 1. `db_optimize.sh` 每次运行留一份完整 DB 副本，永不清理

```bash
BACKUP="${DB_PATH}.bak.${TS}"
cp -a "$DB_PATH" "$BACKUP"
```

这个 `cp -a` 是无条件的 —— 在 `--index-only` 模式下照样执行（它在 `if [[ "$MODE" == "--full" ]]` 判断之前）。而 `install.sh` 和 `update.sh` 每次安装/升级都会调用它。

于是每升一次级，`config/` 下多一份 proxygw.db 全量副本，没有上限也没有清理。这个库装着 `routes_table`、`domain_resolve_cache`、`gateway_events`，在跑久的网关上会到几百 MB —— 升十几次就是几个 GB 的陈年副本。

**修**：保留最新 3 份（`DB_OPTIMIZE_BACKUP_KEEP` 可覆盖），其余删除。

### 2. `flush_cache.sh` 先停服务再检查前提，检查失败把网关撂在停止状态

```bash
systemctl stop proxygw          # 先停
DB_PATH="/root/proxygw/config/proxygw.db"
if [ ! -f "$DB_PATH" ]; then
    echo "Error: Database not found at $DB_PATH"
    exit 1                       # 服务没起回来
fi
```

路径硬编码。任何非默认部署跑这个脚本 = 网关静默下线，而输出只说"数据库找不到"。

**修**：所有前置检查挪到 `systemctl stop` 之前；DB 路径改成可传参；加 `EXIT` trap 保证任何提前退出都把服务拉起来；交互式运行时先确认再删三张表。另外补齐 `set -euo pipefail`（原来只有 `set -e`）。

## P1

### 3. `test_all.sh` 永远报失败

```bash
if go build -o /dev/null ./backend/... 2>/dev/null; then
```

这行在 `ROOT_DIR` 下执行，但根目录**没有 go.mod** —— backend 是独立 module（`module proxygw`）。命令必定失败（`go.mod file not found`），`2>/dev/null` 又把原因吞了。

结果：步骤 [5/6] 恒定失败 → `FAIL=1` → 不管前四步是否全过，`test_all.sh` 永远打印 `❌ Some tests FAILED` 并以 1 退出。

**修**：`(cd "$ROOT_DIR/backend" && go build -o /dev/null ./...)`，并去掉 stderr 重定向。

### 4. `db_optimize.sh` 默认模式是会 VACUUM 的 `--full`

`MODE="${2:---full}"`。手动跑 `db_optimize.sh /path/to/db` 不带第二参数，就会在活着的网关上 VACUUM，全程持写锁。

所有调用方和文档里的两条命令都显式传了模式，所以没有东西依赖这个默认值 —— 但危险的那个才应该需要显式要求。默认改为 `--index-only`，并且无法识别的模式直接报错退出，而不是当成 `--full`。

### 5. `build.sh` 编译完就重启生产服务

一个开发用编译脚本末尾无条件 `systemctl restart proxygw`，在网关上编译一次就断掉所有活动连接。改为默认不重启并打印部署命令；`PROXYGW_RESTART_AFTER_BUILD=1` 保留原行为。

（同文件的 `GOPROXY=https://goproxy.cn,direct` **不是问题**，go.sum 有哈希锁定且 GOSUMDB 默认开启，第三方代理无法悄悄篡改模块内容。这里记一笔以免日后误判。）

## P2

- **`db_optimize.sh` 的 `echo "\n[STEP] ..."` 打不出换行** —— bash 内建 `echo` 不加 `-e` 不解释 `\n`，实际输出是字面量 `\n[STEP] Before snapshot`。6 处全部改 `printf`。
- **`pre-commit.sh`** 算出 `CHANGED` 包列表却只拿来判断非空，实际跑的是全量 `go test ./...`；`2>/dev/null` 把失败原因全吞了，只剩一句 "Tests failed"。改为直接判断是否有 Go 文件入暂存区，并保留测试输出。
- **`test_backend.sh`** 交互式终端分支里 `ARGS+=("-count=1")`（注释却写 "use -v"），而下一行已经写死了 `-count=1` —— 传两次。删掉这段残留。
- **`test_frontend.sh`** 的浏览器检测 grep `--dry-run` 输出里的 `"already installed"`，这个字符串 Playwright 并不保证输出，导致几乎每次都重装 chromium。改为让 Playwright 自己解析浏览器是否存在。
- **`db_optimize.sh`** 补 `sqlite3` 存在性检查。

## 不在本 PR 范围

`check-release-chain.sh` 强制要求 `install.sh` / `update.sh` 里存在 `Using fallback version vX.Y.Z...` 且等于 CHANGELOG 最新版 —— 也就是发布流程在制度上维护着那个硬编码 fallback（api.github.com 被阻断时静默安装写死的老版本）。改动它需要先决定 fallback 本身怎么处理，故未纳入。

（顺带记录：该脚本没有接进任何 CI workflow，只在 CHANGELOG 里被提到"手动执行"。）

## 测试

`scripts/` 没有自动化覆盖，CI 也不碰它。已做的验证：

- 全部 7 个改动脚本通过 `bash -n` 语法检查
- 备份保留逻辑用临时目录干跑验证：5 份备份 → 保留最新 3 份，删除最旧 2 份

`flush_cache.sh` 和 `build.sh` 的行为改动需要在真机上确认一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
