### PR TITLE
fix: verify the REALITY tunnel before reporting a node Online

### DIFF
--- a/backend/remote_deploy/deploy_script.go
+++ b/backend/remote_deploy/deploy_script.go
@@ -7,6 +7,12 @@ import (
 	"strings"
 )
 
+// realityProbeSocksPort is the loopback SOCKS port the post-install REALITY
+// smoke test binds. It only has to be free for the few seconds the probe runs
+// and is never exposed off the host; if it is occupied the probe fails closed
+// and the deploy reports why rather than silently skipping the check.
+const realityProbeSocksPort = 45789
+
 func GenerateWGInstallScript(port int, serverPriv, clientPub, tunnelAddr string) string {
 	clientIP := strings.Replace(tunnelAddr, ".1/24", ".2/32", 1)
 	wgConfig := fmt.Sprintf(`[Interface]
@@ -67,7 +73,7 @@ systemctl restart wg-quick@wg0
 	return fmt.Sprintf(script, wgConfigBase64)
 }
 
-func GenerateVlessRealityInstallScript(port int, uuid, privateKey, shortId, serverName, dest string) string {
+func GenerateVlessRealityInstallScript(port int, uuid, privateKey, publicKey, shortId, serverName, dest string) string {
 	config := map[string]interface{}{
 		"log": map[string]interface{}{"loglevel": "warning"},
 		"inbounds": []map[string]interface{}{
@@ -107,6 +113,50 @@ func GenerateVlessRealityInstallScript(port int, uuid, privateKey, shortId, serv
 
 	configBytes, _ := json.Marshal(config)
 	configBase64 := base64.StdEncoding.EncodeToString(configBytes)
+
+	// probeConfig drives the post-install smoke test below. It is the smallest
+	// client that exercises the exact path a real gateway takes: a REALITY
+	// handshake against the inbound we just wrote, then a VLESS tunnel out.
+	probeConfig := map[string]interface{}{
+		"log": map[string]interface{}{"loglevel": "warning"},
+		"inbounds": []map[string]interface{}{
+			{
+				"listen":   "127.0.0.1",
+				"port":     realityProbeSocksPort,
+				"protocol": "socks",
+				"settings": map[string]interface{}{"udp": false},
+			},
+		},
+		"outbounds": []map[string]interface{}{
+			{
+				"protocol": "vless",
+				"settings": map[string]interface{}{
+					"vnext": []map[string]interface{}{
+						{
+							"address": "127.0.0.1",
+							"port":    port,
+							"users": []map[string]interface{}{
+								{"id": uuid, "encryption": "none", "flow": "xtls-rprx-vision"},
+							},
+						},
+					},
+				},
+				"streamSettings": map[string]interface{}{
+					"network":  "tcp",
+					"security": "reality",
+					"realitySettings": map[string]interface{}{
+						"serverName":  serverName,
+						"fingerprint": "chrome",
+						"publicKey":   publicKey,
+						"shortId":     shortId,
+						"spiderX":     "/",
+					},
+				},
+			},
+		},
+	}
+	probeBytes, _ := json.Marshal(probeConfig)
+	probeBase64 := base64.StdEncoding.EncodeToString(probeBytes)
 
 	script := `#!/bin/bash
 set -e
@@ -178,6 +228,48 @@ XSRV
 systemctl daemon-reload
 systemctl enable xray
 systemctl restart xray
+
+# --- REALITY smoke test ---------------------------------------------------
+# A clean install is not evidence that the node works. REALITY only completes a
+# handshake when dest behaves like a TLS reverse proxy for serverName under the
+# client's ClientHello, and a dest can serve a valid certificate over TLS 1.3
+# while still failing that. Without this probe the deploy reports Online, every
+# client silently falls through to dest, and the node is indistinguishable from
+# a healthy one until someone inspects traffic.
+SMOKE_DIR=$(mktemp -d)
+SMOKE_LOG=$SMOKE_DIR/probe.log
+SMOKE_PID=""
+cleanup_smoke() {
+  if [ -n "$SMOKE_PID" ]; then kill "$SMOKE_PID" 2>/dev/null || true; fi
+  rm -rf "$SMOKE_DIR"
+}
+trap cleanup_smoke EXIT
+
+echo "%s" | base64 -d > "$SMOKE_DIR/probe.json"
+/usr/local/bin/xray run -c "$SMOKE_DIR/probe.json" > "$SMOKE_LOG" 2>&1 &
+SMOKE_PID=$!
+
+smoke_ready=0
+for _ in $(seq 1 30); do
+  if grep -q started "$SMOKE_LOG" 2>/dev/null; then smoke_ready=1; break; fi
+  if ! kill -0 "$SMOKE_PID" 2>/dev/null; then break; fi
+  sleep 0.5
+done
+if [ "$smoke_ready" -ne 1 ]; then
+  echo "REALITY smoke test could not start its probe client (port %d may be in use)." >&2
+  cat "$SMOKE_LOG" >&2
+  exit 1
+fi
+
+if ! curl -sS --max-time 20 -o /dev/null --socks5-hostname 127.0.0.1:%d "https://%s/"; then
+  echo "REALITY smoke test failed: xray is running, but no client can complete a REALITY handshake against it." >&2
+  echo "The usual cause is that dest %s does not work as a REALITY camouflage target from this host." >&2
+  echo "Note that a dest can pass certificate and TLS 1.3 checks and still fail here; pick another dest/serverName pair." >&2
+  echo "Probe client log:" >&2
+  cat "$SMOKE_LOG" >&2
+  exit 1
+fi
+echo "REALITY smoke test passed."
 `
-	return fmt.Sprintf(script, configBase64)
+	return fmt.Sprintf(script, configBase64, probeBase64, realityProbeSocksPort, realityProbeSocksPort, serverName, dest)
 }

--- a/backend/remote_deploy/deploy_script_test.go
+++ b/backend/remote_deploy/deploy_script_test.go
@@ -1,12 +1,13 @@
 package remote_deploy
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 )
 
 func TestGenerateVlessRealityInstallScript_UsesRetryablePackageAndDownloadSteps(t *testing.T) {
-	script := GenerateVlessRealityInstallScript(443, "uuid", "priv", "short", "www.microsoft.com", "www.microsoft.com:443")
+	script := GenerateVlessRealityInstallScript(443, "uuid", "priv", "pub", "short", "www.microsoft.com", "www.microsoft.com:443")
 
 	checks := []string{
 		"retry_cmd()",
@@ -40,4 +41,72 @@ func TestGenerateWGInstallScript_UsesRetryablePackageInstall(t *testing.T) {
 			t.Fatalf("script missing %q\n%s", want, script)
 		}
 	}
+}
+
+// A node whose REALITY handshake does not work is worse than one that fails to
+// install: the deploy reports success, so the outage is only visible by
+// inspecting traffic. The generated script must therefore prove the tunnel
+// works and exit non-zero when it does not, which is what turns the node's
+// status into Failed instead of Online.
+func TestGenerateVlessRealityInstallScript_ProbesTheTunnelAndFailsClosed(t *testing.T) {
+	script := GenerateVlessRealityInstallScript(443, "the-uuid", "priv", "the-pubkey", "the-shortid", "example.com", "example.com:443")
+
+	checks := []string{
+		"REALITY smoke test",
+		"--socks5-hostname 127.0.0.1:45789",
+		`"https://example.com/"`,
+		"trap cleanup_smoke EXIT",
+		"exit 1",
+	}
+	for _, want := range checks {
+		if !strings.Contains(script, want) {
+			t.Fatalf("script missing %q\n%s", want, script)
+		}
+	}
+
+	// The probe must carry the same credentials as the inbound it dials,
+	// otherwise it would fail for reasons unrelated to the camouflage target
+	// and every deploy would break.
+	probe := decodeProbeConfig(t, script)
+	if !strings.Contains(probe, `"the-pubkey"`) {
+		t.Fatalf("probe config does not use the deployed REALITY public key: %s", probe)
+	}
+	if !strings.Contains(probe, `"the-uuid"`) {
+		t.Fatalf("probe config does not use the deployed client id: %s", probe)
+	}
+	if !strings.Contains(probe, `"the-shortid"`) {
+		t.Fatalf("probe config does not use the deployed shortId: %s", probe)
+	}
+
+	// The failure message has to name dest: that is the field an operator has
+	// to change, and it is not otherwise deducible from a handshake error.
+	if !strings.Contains(script, "example.com:443 does not work as a REALITY camouflage target") {
+		t.Fatalf("script does not point at dest on failure\n%s", script)
+	}
+}
+
+// decodeProbeConfig extracts the base64 payload of the probe client config,
+// which is the second one the script writes.
+func decodeProbeConfig(t *testing.T, script string) string {
+	t.Helper()
+	const marker = `echo "`
+	idx := strings.Index(script, "probe.json")
+	if idx < 0 {
+		t.Fatalf("script never writes a probe config\n%s", script)
+	}
+	head := script[:idx]
+	start := strings.LastIndex(head, marker)
+	if start < 0 {
+		t.Fatalf("no base64 payload before the probe config\n%s", script)
+	}
+	start += len(marker)
+	end := strings.Index(script[start:], `"`)
+	if end < 0 {
+		t.Fatalf("unterminated base64 payload\n%s", script)
+	}
+	raw, err := base64.StdEncoding.DecodeString(script[start : start+end])
+	if err != nil {
+		t.Fatalf("probe config is not valid base64: %v", err)
+	}
+	return string(raw)
 }

--- a/backend/remote_nodes_controller.go
+++ b/backend/remote_nodes_controller.go
@@ -407,7 +407,7 @@ func doDeployRoutine(id int64, req RemoteNodeReq, isUpdate bool, params map[stri
 			return
 		}
 
-		script = remote_deploy.GenerateVlessRealityInstallScript(port, uuid, rPriv, shortId, serverName, dest)
+		script = remote_deploy.GenerateVlessRealityInstallScript(port, uuid, rPriv, rPub, shortId, serverName, dest)
 	}
 
 	logAction(id, "deploy", "running", "Executing installation script on remote host...")


### PR DESCRIPTION
## The bug

A VLESS/REALITY node is marked `Online` as soon as the install script exits 0 (`remote_nodes_controller.go:429`), and `checkRemoteNode` only runs `systemctl is-active xray`. Neither observes the property that actually matters: **whether a client can complete a REALITY handshake against the new inbound.**

REALITY completes that handshake only when `dest` behaves like a TLS reverse proxy for `serverName` under the client's ClientHello. A `dest` can resolve, accept TCP, negotiate TLS 1.3, and serve a certificate that validates for `serverName` — and still fail. `ValidateRealityParams` is purely syntactic, so it cannot catch this.

The result is the worst failure mode available: **the node reports `Online`, every client silently falls through to `dest`, and it looks identical to a healthy node until someone inspects traffic.**

### How I hit it

Deploying with the package default `dest` (`www.microsoft.com:443`) produced a node that reported `Online` while no traffic ever traversed it. Reproduced with a hand-written REALITY pair over loopback — no NAT, MTU, clock skew, or key mismatch involved:

| dest | REALITY handshake |
|---|---|
| `www.microsoft.com` | fails (0/3, twice) |
| `www.apple.com` | works (3/3) |
| `www.cloudflare.com` | works |
| `addons.mozilla.org` | works |

Both `www.microsoft.com` and `www.apple.com` presented TLS 1.3, `X25519MLKEM768`, ALPN `h2`, and `Verify return code: 0`, and both accepted a plain-X25519-only ClientHello. All four uTLS fingerprints (`chrome`/`firefox`/`safari`/`random`) failed against Microsoft. **No preflight TLS check would have caught this — only an actual REALITY handshake does.**

I deliberately did **not** change `DefaultRealityDest`. I can only show it fails from the networks I tested, and swapping one hardcoded host for another is whack-a-mole. The environment-independent bug is that a dead node reports `Online`.

## The fix

Append a smoke test to the generated install script: start a throwaway xray client on loopback carrying the same uuid, REALITY public key and shortId as the inbound just written, and fetch `https://<serverName>/` through it.

On failure the script exits non-zero, which the **existing** deploy path already turns into status `Failed` — no controller changes needed. The failure message names `dest` as the field to change and notes that passing certificate/TLS checks does not imply a usable camouflage target, which is the non-obvious part.

`GenerateVlessRealityInstallScript` now also takes the REALITY public key, which the caller already had to hand.

## Verification

Unit tests cover the generated script and assert the probe carries the deployed credentials.

More importantly, the probe logic was run against real nodes on a Debian 13 / x86_64 host:

| node | old logic | with this change |
|---|---|---|
| working (`dest=www.apple.com`) | `Online` | passes, no false positive |
| broken (`dest=www.microsoft.com`, xray process alive) | **`Online` (wrong)** | **exits 1 → `Failed`** |

`go build ./...` and `go vet ./...` are clean. `go test ./... -short` has 3 pre-existing failures (`TestBuildXrayDownloadURL{Empty,Latest,Specific}`) — identical on unmodified `main`, so no regression from this change.

## Notes for review

- The probe binds a fixed loopback port (`45789`) for a few seconds. If it is occupied the probe fails closed and says so rather than silently skipping the check — happy to switch to a dynamically chosen port if you prefer.
- The probe egresses to `serverName` over the tunnel. That host is already a hard requirement for REALITY, so this adds no new external dependency.
- This makes deploys with an unusable `dest` fail loudly where they previously "succeeded". That is the intent, and it matches the existing comments in `ValidateRealityServerName` about turning silent outages into deploy-time errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
