### PR TITLE
fix: stage the nftables ruleset somewhere the unit can actually write

### DIFF
--- a/backend/nftables_paths_test.go
+++ b/backend/nftables_paths_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The unit runs with ProtectSystem=strict, so /etc is read-only apart from the
+// paths ReadWritePaths bind-mounts. A ReadWritePaths entry cannot make a file
+// that does not exist yet writable — the "-" prefix makes systemd skip it — so
+// putting scratch files under /etc left every apply failing with "read-only
+// file system", and the gateway silently stopped being able to update its own
+// firewall. These paths must stay somewhere the unit can actually create files.
+func TestNftablesScratchPathsAreWritableUnderSandbox(t *testing.T) {
+	tmp := os.TempDir()
+	for _, tc := range []struct {
+		name string
+		got  string
+	}{
+		{"staging", nftablesStagingPath()},
+		{"runtime backup", nftablesRuntimeBackupPath()},
+	} {
+		if strings.HasPrefix(tc.got, "/etc/") {
+			t.Fatalf("%s path %q is under /etc, which ProtectSystem=strict makes read-only", tc.name, tc.got)
+		}
+		if filepath.Dir(tc.got) != filepath.Clean(tmp) {
+			t.Fatalf("%s path %q is not under TempDir %q", tc.name, tc.got, tmp)
+		}
+	}
+
+	if nftablesStagingPath() == nftablesRuntimeBackupPath() {
+		t.Fatal("staging and runtime backup must not collide: the deferred cleanup of one would delete the other")
+	}
+}
+
+// The active ruleset is the one file in /etc the unit legitimately rewrites; it
+// ships with every install, so the bind-mount applies.
+func TestNftablesActivePathIsTheSystemdLoadedRuleset(t *testing.T) {
+	if nftablesActivePath != "/etc/nftables.conf" {
+		t.Fatalf("active path %q is not the ruleset nftables.service loads at boot", nftablesActivePath)
+	}
+}
+
+// A scratch path that is actually creatable is the whole point, so prove it
+// rather than trusting the prefix check above.
+func TestNftablesStagingPathIsCreatable(t *testing.T) {
+	p := nftablesStagingPath()
+	if err := os.WriteFile(p, []byte("# probe\n"), 0644); err != nil {
+		t.Fatalf("cannot create staging file %q: %v", p, err)
+	}
+	t.Cleanup(func() { os.Remove(p) })
+}

--- a/backend/nftables_service.go
+++ b/backend/nftables_service.go
@@ -92,6 +92,28 @@ table inet proxygw {
 }
 `
 
+// nftablesActivePath is the persisted ruleset systemd loads at boot. It already
+// exists on any installed host, so ReadWritePaths can bind-mount it read-write
+// even though ProtectSystem=strict keeps the rest of /etc read-only.
+const nftablesActivePath = "/etc/nftables.conf"
+
+// nftablesStagingPath returns the scratch file "nft -c -f" validates before the
+// ruleset is committed. It deliberately does not live in /etc: the unit runs
+// under ProtectSystem=strict, and a ReadWritePaths entry cannot rescue a file
+// that does not exist yet, because the "-" prefix makes systemd skip it. That
+// left every apply failing with "read-only file system" and the gateway unable
+// to update its own firewall. TempDir is private to the unit (PrivateTmp) and
+// is where the runtime backup already lives.
+func nftablesStagingPath() string {
+	return filepath.Join(os.TempDir(), "proxygw-nftables-staging.nft")
+}
+
+// nftablesRuntimeBackupPath returns the dump of the live ruleset kept for
+// rollback if committing the new one fails.
+func nftablesRuntimeBackupPath() string {
+	return filepath.Join(os.TempDir(), "proxygw-nftables-runtime-backup.nft")
+}
+
 func applyNftablesConfig() error {
 	var defaultPolicy string
 	if err := getDB().QueryRow("SELECT value FROM settings WHERE key='lan_default_policy'").Scan(&defaultPolicy); err != nil {
@@ -210,9 +232,9 @@ func applyNftablesConfig() error {
 	}
 
 	newConfig := buf.Bytes()
-	stagingPath := "/etc/nftables.conf.proxygw.new"
-	activePath := "/etc/nftables.conf"
-	runtimeBackupPath := filepath.Join(os.TempDir(), "proxygw-nftables-runtime-backup.nft")
+	activePath := nftablesActivePath
+	stagingPath := nftablesStagingPath()
+	runtimeBackupPath := nftablesRuntimeBackupPath()
 
 	if err := os.WriteFile(stagingPath, newConfig, 0644); err != nil {
 		return fmt.Errorf("failed to stage nftables config: %v", err)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -177,7 +177,7 @@ PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes
 RestrictSUIDSGID=yes
-ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf -/etc/nftables.conf.proxygw.new -/etc/nftables.conf.proxygw.bak
+ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -102,7 +102,7 @@ PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes
 RestrictSUIDSGID=yes
-ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf -/etc/nftables.conf.proxygw.new -/etc/nftables.conf.proxygw.bak
+ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/proxygw.service
+++ b/systemd/proxygw.service
@@ -19,7 +19,7 @@ PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes
 RestrictSUIDSGID=yes
-ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf -/etc/nftables.conf.proxygw.new -/etc/nftables.conf.proxygw.bak
+ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## The bug

`proxygw.service` runs with `ProtectSystem=strict`, which mounts `/etc` read-only. `applyNftablesConfig` wrote its validation scratch file to `/etc/nftables.conf.proxygw.new`, so **every apply — including the one on startup — failed**:

```
[WARN] applyNftablesConfig on startup failed: failed to stage nftables config:
open /etc/nftables.conf.proxygw.new: read-only file system
```

The gateway could therefore never update its own firewall after install. Reproduced on a fresh Debian 13 install; observed on every boot.

### Why ReadWritePaths did not cover it

The entries carry a `-` prefix, which tells systemd to **skip a path that does not exist**. The staging file is created by this function, so it never exists at unit start and never gets a read-write bind mount. Only the paths that already exist on disk — `/etc/nftables.conf`, `/etc/frr` — actually get one, which is exactly why writing the *active* ruleset worked while staging did not.

Verified from inside the running unit's mount namespace:

```
/etc/frr/frr.conf     writable      (exists -> bind-mounted rw)
/etc/nftables.conf    writable      (exists -> bind-mounted rw)
/etc/nftables.conf.proxygw.new   Read-only file system
```

## The fix

The staging file exists only to give `nft -c -f` something to validate and is removed a few lines later, so it has no reason to live in `/etc`. Move it to `TempDir`, which `PrivateTmp=yes` already makes private to the unit and where the runtime rollback dump is written today. The nft template has no `include` directives, so its location is free.

Drop the two now-unused `/etc/nftables.conf.proxygw.*` entries from the unit in all three places that write it (`systemd/proxygw.service`, `scripts/install.sh`, `scripts/update.sh`). The `.bak` path was already dead — nothing in the tree has ever referenced it.

The paths are extracted into helpers so the invariant is testable, and the test actually creates the staging file rather than only asserting a prefix.

## Verification

`go build ./...` and `go vet ./...` clean. New tests pass alongside the existing nftables suite.

Found while auditing a live deployment; the same box also showed the active ruleset was whatever `install.sh` wrote at install time and had never been reconciled by the backend since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
