### PR TITLE
fix: create /run/proxygw before validating the generated Xray config

### DIFF
--- a/backend/app_service.go
+++ b/backend/app_service.go
@@ -3,8 +3,23 @@ package main
 import (
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
+)
+
+// runtimeDir holds the Xray access/error logs the connection tracker tails. It
+// lives on tmpfs, so it is gone after every reboot and has to be recreated
+// before anything that references it runs.
+const runtimeDir = "/run/proxygw"
+
+// xrayAccessLogPath / xrayErrorLogPath are what the generated Xray config points
+// at and what the connection tracker tails. Keeping them derived from runtimeDir
+// stops the two from drifting: Xray exits 23 if it cannot open the access log,
+// and xray.service refuses to restart on that status.
+var (
+	xrayAccessLogPath = filepath.Join(runtimeDir, "xray_access.log")
+	xrayErrorLogPath  = filepath.Join(runtimeDir, "xray_error.log")
 )
 
 // AppService orchestrates subsystem startup.
@@ -18,6 +33,18 @@ func NewAppService(repo *AppRepository) *AppService {
 
 func (s *AppService) Bootstrap() {
 	s.repo.InitDB()
+
+	// Must precede applyXrayConfig: the generated Xray config points its access
+	// log at /run/proxygw/xray_access.log, and Xray refuses to start — exit 23,
+	// "failed to initialize access logger" — if the directory is missing. That
+	// makes the config validation reject a perfectly good config on the first
+	// boot after install, and xray.service sets RestartPreventExitStatus=23, so
+	// the unit stays down instead of retrying. The connection tracker and the
+	// database maintenance job read the same directory.
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		log.Printf("[WARN] failed to create runtime dir %s: %v", runtimeDir, err)
+	}
+
 	ensureGeodataHealthy()
 	goSafe(startTrafficMonitor)
 	goSafe(startNftablesMonitor)
@@ -32,7 +59,6 @@ func (s *AppService) Bootstrap() {
 		log.Printf("[WARN] applyNftablesConfig on startup failed: %v", err)
 	}
 
-	os.MkdirAll("/run/proxygw", 0755)
 	StartConnectionTracker()
 	s.initTPROXYRules()
 	goSafe(s.reconcileTPROXYRulesLoop)

--- a/backend/connection_tracker.go
+++ b/backend/connection_tracker.go
@@ -74,7 +74,7 @@ func GetRecentConnections() []ConnectionRecord {
 }
 
 func StartConnectionTracker() {
-	logPath := "/run/proxygw/xray_access.log"
+	logPath := xrayAccessLogPath
 
 	go func() {
 		defer func() {

--- a/backend/db_maintenance.go
+++ b/backend/db_maintenance.go
@@ -24,8 +24,8 @@ func runDatabaseMaintenance() {
 func rotateLogs() {
 	logPaths := []string{
 		getPath("core", "mosdns", "mosdns.log"),
-		"/run/proxygw/xray_access.log",
-		"/run/proxygw/xray_error.log",
+		xrayAccessLogPath,
+		xrayErrorLogPath,
 	}
 
 	const maxLogSize = 50 * 1024 * 1024 // 50MB

--- a/backend/runtime_dir_test.go
+++ b/backend/runtime_dir_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Xray exits 23 when it cannot open its access log, and xray.service sets
+// RestartPreventExitStatus=23, so a missing runtime directory does not produce
+// a retry loop — it leaves the unit down until something restarts it by hand.
+// On a fresh install that surfaced as the backend rejecting its own freshly
+// generated config ("failed to initialize access logger"). Keeping every
+// consumer derived from runtimeDir is what makes creating that one directory
+// sufficient.
+func TestXrayLogPathsLiveUnderRuntimeDir(t *testing.T) {
+	for name, p := range map[string]string{
+		"access log": xrayAccessLogPath,
+		"error log":  xrayErrorLogPath,
+	} {
+		if filepath.Dir(p) != runtimeDir {
+			t.Fatalf("%s %q is not under runtimeDir %q; creating runtimeDir at boot would not cover it", name, p, runtimeDir)
+		}
+	}
+	if xrayAccessLogPath == xrayErrorLogPath {
+		t.Fatal("access and error log must be distinct files")
+	}
+}
+
+// The generated config is what Xray actually validates and loads, so the path
+// it carries is the one that has to exist.
+func TestGeneratedXrayConfigUsesTheRuntimeAccessLog(t *testing.T) {
+	for _, mode := range []string{"A", "B", "C"} {
+		cfg := buildBaseXrayConfig(mode)
+		logSection, ok := cfg["log"].(map[string]string)
+		if !ok {
+			t.Fatalf("mode %s: config has no log section of the expected shape", mode)
+		}
+		got := logSection["access"]
+		if got != xrayAccessLogPath {
+			t.Fatalf("mode %s: config logs access to %q, but the backend only creates %q", mode, got, runtimeDir)
+		}
+		if !strings.HasPrefix(got, runtimeDir+"/") {
+			t.Fatalf("mode %s: access log %q escapes runtimeDir %q", mode, got, runtimeDir)
+		}
+	}
+}

--- a/backend/xray_service.go
+++ b/backend/xray_service.go
@@ -11,7 +11,7 @@ import (
 
 func buildBaseXrayConfig(mode string) map[string]interface{} {
 	config := map[string]interface{}{
-		"log":   map[string]string{"loglevel": "warning", "access": "/run/proxygw/xray_access.log"},
+		"log":   map[string]string{"loglevel": "warning", "access": xrayAccessLogPath},
 		"api":   map[string]interface{}{"services": []string{"StatsService", "RoutingService", "HandlerService"}, "tag": "api"},
 		"stats": map[string]interface{}{},
 		"policy": map[string]interface{}{


### PR DESCRIPTION
## The bug

`Bootstrap()` created the runtime directory **after** `applyXrayConfig()` had already run:

```go
applyMosdnsConfig()
applyXrayConfig()          // validates a config pointing at /run/proxygw/xray_access.log
applyNftablesConfig()

os.MkdirAll("/run/proxygw", 0755)   // too late
```

So on the first boot after an install the backend rejected its own freshly generated config:

```
Failed to start: main: failed to create server > app/log: failed to initialize
access logger > open /run/proxygw/xray_access.log: no such file or directory
[ERROR] Xray config validation failed: exit status 23. Config rejected.
```

`/run` is tmpfs, so the directory is missing after **every** reboot, not just the first.

This is made worse by `RestartPreventExitStatus=23` in `xray.service`. That is the right call for a genuinely bad config — it stops a restart loop from flooding the journal — but here it means the unit stays down instead of retrying once the directory exists. Observed on a fresh Debian 13 install: xray only came up later, when an unrelated code path happened to restart it.

## The fix

Move the `MkdirAll` to the top of `Bootstrap`, and log a failure rather than discarding the error.

Four files hardcoded `/run/proxygw/xray_access.log` (`xray_service.go`, `connection_tracker.go`, and twice in `db_maintenance.go`). Derive them from a single `runtimeDir` constant so creating that one directory provably covers every consumer and the paths cannot drift apart.

## Verification

`go build ./...` and `go vet ./...` clean. New tests assert the log paths stay under `runtimeDir` and that the config `buildBaseXrayConfig` generates — the one Xray actually validates — points at the path the backend creates, for all three modes.

Found while auditing a live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
