### PR TITLE
fix: stop emitting ICMP redirects that let clients bypass Mode A

### DIFF
--- a/backend/app_service.go
+++ b/backend/app_service.go
@@ -60,8 +60,41 @@ func (s *AppService) Bootstrap() {
 	}
 
 	StartConnectionTracker()
+	disableSendRedirects()
 	s.initTPROXYRules()
 	goSafe(s.reconcileTPROXYRulesLoop)
+}
+
+// ipv4ConfDir is the sysctl tree for per-interface IPv4 settings. It is a
+// variable so tests can point it at a fixture.
+var ipv4ConfDir = "/proc/sys/net/ipv4/conf"
+
+// disableSendRedirects turns ICMP redirects off on every interface that exists
+// right now, not just on "all" and "default".
+//
+// 99-proxygw.conf sets conf.all and conf.default, but neither covers an
+// interface that already existed when the file was applied: "default" only
+// seeds interfaces created afterwards, and for send_redirects the kernel takes
+// the logical OR of conf.all and conf.<iface>, so a pre-existing interface
+// keeps its default of 1 and redirects are still emitted.
+//
+// That is fatal to Mode A. The gateway routes for LAN clients whose next hop
+// sits on the same subnet, so it answers with an ICMP redirect, the client
+// caches it and then talks to the main router directly. Traffic stops entering
+// the TPROXY chain at all — the gateway is bypassed, silently, for exactly the
+// destinations a user is most likely to test.
+func disableSendRedirects() {
+	entries, err := os.ReadDir(ipv4ConfDir)
+	if err != nil {
+		log.Printf("[WARN] cannot enumerate %s to disable ICMP redirects: %v", ipv4ConfDir, err)
+		return
+	}
+	for _, e := range entries {
+		p := filepath.Join(ipv4ConfDir, e.Name(), "send_redirects")
+		if err := os.WriteFile(p, []byte("0\n"), 0644); err != nil && !os.IsNotExist(err) {
+			log.Printf("[WARN] failed to disable send_redirects on %s: %v", e.Name(), err)
+		}
+	}
 }
 
 func (s *AppService) initTPROXYRules() {

--- a/backend/send_redirects_test.go
+++ b/backend/send_redirects_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A gateway that emits ICMP redirects tells LAN clients to reach the internet
+// through the main router directly. The client caches that and its traffic
+// stops entering the TPROXY chain entirely, so Mode A is bypassed without any
+// error anywhere. conf.all and conf.default do not prevent this on interfaces
+// that already existed, so every interface has to be written explicitly.
+func TestDisableSendRedirectsCoversEveryInterface(t *testing.T) {
+	root := t.TempDir()
+	ifaces := []string{"all", "default", "lo", "eth0", "br-lan"}
+	for _, n := range ifaces {
+		dir := filepath.Join(root, n)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "send_redirects"), []byte("1\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	old := ipv4ConfDir
+	ipv4ConfDir = root
+	t.Cleanup(func() { ipv4ConfDir = old })
+
+	disableSendRedirects()
+
+	for _, n := range ifaces {
+		b, err := os.ReadFile(filepath.Join(root, n, "send_redirects"))
+		if err != nil {
+			t.Fatalf("%s: %v", n, err)
+		}
+		if got := string(b); got != "0\n" {
+			t.Fatalf("send_redirects on %s is %q, want \"0\\n\"; a pre-existing interface left at 1 re-enables the redirect that bypasses the gateway", n, got)
+		}
+	}
+}
+
+// An unreadable sysctl tree must not take the gateway down with it.
+func TestDisableSendRedirectsToleratesMissingTree(t *testing.T) {
+	old := ipv4ConfDir
+	ipv4ConfDir = filepath.Join(t.TempDir(), "does-not-exist")
+	t.Cleanup(func() { ipv4ConfDir = old })
+	disableSendRedirects() // must not panic
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -119,6 +119,15 @@ net.ipv4.tcp_fastopen = 3
 SYSCTL_EOF
 sysctl --system || true
 
+# conf.default only seeds interfaces created after it is applied, and for
+# send_redirects the kernel ORs conf.all with conf.<iface>, so every interface
+# that already existed keeps the default of 1 and the gateway still emits ICMP
+# redirects. A redirected client then talks to the main router directly and
+# never enters the TPROXY chain, which silently defeats Mode A.
+for _redir in /proc/sys/net/ipv4/conf/*/send_redirects; do
+    [ -w "$_redir" ] && echo 0 > "$_redir" || true
+done
+
 
 echo "[3/6] Setting up directory structure..."
 mkdir -p "$REPO_DIR/config"


### PR DESCRIPTION
## The bug

`99-proxygw.conf` sets `net.ipv4.conf.all.send_redirects = 0` and `net.ipv4.conf.default.send_redirects = 0`. Neither reaches an interface that already existed when the file was applied:

- `default` only seeds interfaces created **after** it is set
- for `send_redirects` the kernel takes the **logical OR** of `conf.all` and `conf.<iface>`

On a gateway installed the normal way, the result is:

```
all      0
default  0
eth0     1     <-- still emitting redirects
```

Mode A is precisely the shape that triggers a redirect: the gateway routes for LAN clients whose next hop (the main router) sits on the same subnet. The client caches the redirect and from then on talks to the main router directly. **Its traffic stops entering the TPROXY chain at all.** Nothing logs an error — the gateway just stops seeing the packets it exists to hijack.

## Measured on a live gateway

With `eth0` at 1, the client's route to a destination it had used:

```
142.251.157.119 via 192.168.100.1 dev eth0 src 192.168.100.50
    cache <redirected>
```

— pointing at the main router, not the gateway. Both nftables counters were flat:

```
mode_a_quic_reject    packets 0 bytes 0
proxy_default_v4      packets 0 bytes 0
```

After writing 0 to `eth0/send_redirects` and flushing the client's route cache:

```
142.251.157.119 via 192.168.100.199 dev eth0 src 192.168.100.50

mode_a_quic_reject    packets 5 bytes 300      <- exactly the 5 UDP/443 probes sent
proxy_default_v4      packets 55 bytes 4764
```

Worth noting: the QUIC reject rule had **never fired** — not because it is wrong, but because no packet ever reached it. The same was true of every other Mode A rule for a redirected destination.

Modes B and C are unaffected: there the client's default gateway is the main router, so the gateway never routes for it and never emits a redirect.

## The fix

Write `send_redirects = 0` to every interface present in `/proc/sys/net/ipv4/conf`, at backend startup and again in `install.sh` so a fresh install is correct before the backend ever restarts. Interfaces created later are still covered by the existing `conf.default` entry.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` clean. New tests cover that every interface directory is written (not just `all`/`default`) and that a missing sysctl tree is tolerated rather than fatal.

Found while verifying that each of the three modes actually meets its documented design goal on a live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
