### PR TITLE
fix: install dig, without which Mode C publishes nothing

### DIFF
--- a/backend/app_service.go
+++ b/backend/app_service.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -59,6 +60,7 @@ func (s *AppService) Bootstrap() {
 		log.Printf("[WARN] applyNftablesConfig on startup failed: %v", err)
 	}
 
+	warnIfResolverMissing()
 	StartConnectionTracker()
 	disableSendRedirects()
 	s.initTPROXYRules()
@@ -94,6 +96,27 @@ func disableSendRedirects() {
 		if err := os.WriteFile(p, []byte("0\n"), 0644); err != nil && !os.IsNotExist(err) {
 			log.Printf("[WARN] failed to disable send_redirects on %s: %v", e.Name(), err)
 		}
+	}
+}
+
+// resolverBinary is the only DNS path the OSPF engine has: ospf_dns_cache.go
+// shells out to it, and the Go resolver was removed in 1.7.20 so there is no
+// fallback. lookPath is a variable so tests can drive both outcomes.
+const resolverBinary = "dig"
+
+var lookPath = exec.LookPath
+
+// warnIfResolverMissing reports a missing dig once, at startup, instead of
+// letting every rule fail on its own.
+//
+// Without it Mode C publishes nothing at all — every domain and geosite rule
+// fails to resolve — and Mode B cannot resolve protected hosts. The only
+// evidence is one "executable file not found in $PATH" line per rule per
+// sync, which reads like a per-rule DNS problem rather than a missing
+// dependency.
+func warnIfResolverMissing() {
+	if _, err := lookPath(resolverBinary); err != nil {
+		log.Printf("[ERROR] %q is not installed; the OSPF engine cannot resolve any domain or geosite rule, so Mode C will publish no routes and Mode B cannot resolve protected hosts. Install it with: apt-get install -y bind9-dnsutils", resolverBinary)
 	}
 }
 

--- a/backend/resolver_check_test.go
+++ b/backend/resolver_check_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(old) })
+	fn()
+	return buf.String()
+}
+
+// A missing dig disables the whole OSPF resolution path, but the only symptom
+// is one "executable file not found" line per rule per sync, which reads like a
+// DNS problem with that rule. Say it once, plainly, with the fix.
+func TestWarnIfResolverMissingNamesTheDependencyAndTheFix(t *testing.T) {
+	old := lookPath
+	lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	t.Cleanup(func() { lookPath = old })
+
+	out := captureLog(t, warnIfResolverMissing)
+
+	for _, want := range []string{resolverBinary, "Mode C", "bind9-dnsutils"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("warning does not mention %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestWarnIfResolverMissingSilentWhenPresent(t *testing.T) {
+	old := lookPath
+	lookPath = func(string) (string, error) { return "/usr/bin/dig", nil }
+	t.Cleanup(func() { lookPath = old })
+
+	if out := captureLog(t, warnIfResolverMissing); strings.TrimSpace(out) != "" {
+		t.Fatalf("warned even though the resolver is installed:\n%s", out)
+	}
+}
+
+// The install path has to actually install it, or the warning is all a fresh
+// deployment ever gets.
+func TestInstallScriptsInstallTheResolver(t *testing.T) {
+	for _, f := range []string{"../scripts/install.sh", "../scripts/update.sh"} {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("%s: %v", f, err)
+		}
+		if !strings.Contains(string(b), "bind9-dnsutils") {
+			t.Fatalf("%s never installs a dig provider; Mode C would publish nothing on a fresh host", f)
+		}
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,6 +46,11 @@ cd "$REPO_DIR"
 echo "[1/6] Installing system dependencies..."
 apt-get update
 apt-get install -y nftables frr curl wget unzip iproute2 jq
+# The OSPF engine resolves every domain and geosite rule by shelling out to dig
+# (ospf_dns_cache.go is the only resolution path since the Go resolver was
+# dropped in 1.7.20). Without it Mode C publishes nothing at all and Mode B
+# cannot resolve protected hosts. dnsutils is the pre-bookworm name.
+apt-get install -y bind9-dnsutils || apt-get install -y dnsutils
 
 echo "[2/6] Setting up routing rules and system settings..."
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -15,6 +15,9 @@ cd "$REPO_DIR"
 
 apt-get update >/dev/null 2>&1 || true
 apt-get install -y jq sqlite3 wget >/dev/null 2>&1 || true
+# Installs from before dig became a hard dependency have no resolver at all;
+# without it the OSPF engine silently resolves nothing.
+command -v dig >/dev/null 2>&1 || apt-get install -y bind9-dnsutils >/dev/null 2>&1 || apt-get install -y dnsutils >/dev/null 2>&1 || true
 
 echo "=== EdgeRouteGW Update ==="
 


### PR DESCRIPTION
## The bug

`ospf_dns_cache.go` shells out to `dig` for every domain and geosite rule, and it is the **only** resolution path left — the Go resolver was removed in 1.7.20 and the remaining fallbacks in 1.7.21, both deliberately.

`install.sh` installs `nftables frr curl wget unzip iproute2 jq`. It has never installed `dig`.

On a stock install, every resolution fails:

```
[OSPF] domain "www.google.com" (proxy) resolve failed: resolve www.google.com
failed: dig execution failed: exec: "dig": executable file not found in $PATH
[OSPF] resolve protected host "www.apple.com" failed: ... same
```

`routes_table` stays empty, nothing is ever published, and the main router receives no routes.

**Mode C — whose entire premise is resolving domain rules and publishing the real IPs over OSPF — does not work at all on a fresh host.** Mode B still carries traffic, because its `198.18.0.0/16` route is static in `frr.conf` and needs no DNS, but its protected-host resolution fails the same way.

## Observed on a fresh v1.7.23 install

Gateway in Mode C, one `domain` rule (`www.google.com`, policy `proxy`), OSPF adjacency `Full` with the main router:

```
GET /api/ospf  ->  {"neighbors":1,"pending":0,"published":0}
routes_table    ->  0 rows
ROS route table ->  no OSPF routes
```

A client with its default gateway on the main router downloaded 86 KB from a rule-matched domain and the gateway's outbound counters moved by ~1 KB — the traffic bypassed the gateway entirely, because the main router had no route pointing at it.

`command -v dig` on that gateway: nothing. `journalctl -b -u proxygw | grep -c "dig.*not found"`: 10.

## Why it is easy to miss

The failure is one `executable file not found in $PATH` line **per rule per sync**, buried among normal OSPF reconcile lines. It reads like a DNS problem with that particular rule, not a missing package. Nothing at startup says the resolver is absent, and the modes that do not need DNS keep working.

## The fix

- `install.sh` installs a dig provider (`bind9-dnsutils`, falling back to `dnsutils` for pre-bookworm)
- `update.sh` backfills it for hosts installed before dig became a hard dependency
- the backend says so once at startup, naming the consequence and the package, instead of once per rule

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` clean. Tests cover both branches of the startup check and assert that the install scripts really do install a provider — the warning alone would be no help to a fresh deployment.

Found while verifying that each of the three modes meets its documented design goal on a live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
