### PR TITLE
release: v1.7.24

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [1.7.24] - 2026-09-05
+### 🐛 三模式验证修复 (Mode Verification Fixes)
+- **Mode A 被 ICMP 重定向静默绕过**: `99-proxygw.conf` 只设了 `conf.all` 与 `conf.default` 的 `send_redirects=0`，二者都覆盖不到安装时已存在的网卡——`default` 仅对之后创建的接口生效，而 `send_redirects` 的有效值是 `conf.all` 与 `conf.<iface>` 的**逻辑或**，因此 `eth0` 保持默认值 1 并继续发送重定向。Mode A 恰好是产生重定向的典型形态（网关为下一跳在同网段的客户端做路由），客户端收到后改为直连主路由，**流量彻底不再进入 TPROXY 链**，且无任何报错。实测：`eth0=1` 时客户端路由为 `via 主路由 ... cache <redirected>`、两个 nft 计数器恒为 0；置 0 并清缓存后路由回到网关，`proxy_default_v4` 立刻计到 55 包，而 Mode A 的 QUIC 阻断规则也首次命中（5/5 探测包）——此前它从未触发过，只因没有包能到达它。修复为在启动与安装时对每一张已存在的网卡显式写 0。
+- **Mode C 因缺少 dig 完全不工作**: `ospf_dns_cache.go` 通过 shell 调用 `dig` 解析每一条 domain/geosite 规则，且自 1.7.20 移除 Go 解析器后这是**唯一**解析路径；而 `install.sh` 从未安装过它。全新安装上每次解析都失败（`exec: "dig": executable file not found in $PATH`），`routes_table` 恒为空，主路由收不到任何路由——**Mode C 的立身之本（解析域名并经 OSPF 播报真实 IP）在任何标准安装上都不成立**。Mode B 因 `198.18.0.0/16` 是 frr.conf 里的静态路由而仍能转发，但其保护主机解析同样失效。修复为在 install.sh 安装、update.sh 补装 dig 提供者，并在启动时给出一次明确告警（此前只有每条规则每轮一行、极易被误读为该规则自身的 DNS 问题）。
+
 ## [1.7.23] - 2026-09-05
 ### 🐛 部署与运行时修复 (Deployment & Runtime Fixes)
 - **REALITY 隧道部署自检**: 远程节点部署完成后会实际发起一次 REALITY 握手并经隧道取一次 `https://<serverName>/`，失败则部署置为 `Failed` 并直接指出应更换的 `dest`。此前只要安装脚本退出码为 0 就标记 `Online`，`check` 也仅执行 `systemctl is-active xray`，导致隧道完全不通的节点被报告为健康，只有抓包才能发现。

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
 <head>
-    <meta name="app-version" content="EdgeRouteGW v1.7.23">
+    <meta name="app-version" content="EdgeRouteGW v1.7.24">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -157,8 +157,8 @@ fi
 
 # Ultimate fallback if both git and API fail (GFW block / no IPv4)
 if [ -z "$PROXYGW_LATEST" ]; then
-    echo "Warning: API blocked. Using fallback version v1.7.23..."
-    PROXYGW_LATEST="v1.7.23"
+    echo "Warning: API blocked. Using fallback version v1.7.24..."
+    PROXYGW_LATEST="v1.7.24"
 fi
 if [ "$ARCH" = "x86_64" ]; then
     wget -q -4 -O "$REPO_DIR/backend/proxygw-backend" "https://github.com/zlylong/EdgeRouteGW/releases/download/${PROXYGW_LATEST}/proxygw-backend-linux-amd64"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -64,8 +64,8 @@ fi
 
 # Ultimate fallback if both API and tags fail
 if [ -z "$PROXYGW_LATEST" ]; then
-    echo "Warning: release tag detect failed. Using fallback version v1.7.23..."
-    PROXYGW_LATEST="v1.7.23"
+    echo "Warning: release tag detect failed. Using fallback version v1.7.24..."
+    PROXYGW_LATEST="v1.7.24"
 fi
 
 echo "Using release tag: $PROXYGW_LATEST"


### PR DESCRIPTION
Cuts v1.7.24 with the two mode-correctness fixes merged since v1.7.23 (#31, #32).

Both were found by testing each of the three modes against its documented design goal on a live deployment, and both were silent: the install succeeded, every service reported healthy, and the mode simply did not do what it promises.

## What ships

**#31 — Mode A was bypassed by redirects the gateway sent itself.** `conf.all` and `conf.default` do not reach an interface that already existed, and `send_redirects` is the OR of `all` and `<iface>`, so `eth0` stayed at 1. Mode A is exactly the shape that produces a redirect, so clients cached "use the main router" and their traffic stopped entering the TPROXY chain. The Mode A QUIC reject rule had never fired once — not because it was wrong, but because no packet ever reached it.

**#32 — Mode C could never publish anything.** `ospf_dns_cache.go` shells out to `dig` for every domain and geosite rule and is the only resolver left since 1.7.20; `install.sh` has never installed it. `routes_table` stayed empty, `published` stayed 0, and the main router got no routes.

## Release chain

`check-release-chain.sh` → `ok: release chain aligned with v1.7.24`. Release-notes extraction was run against this branch: 5 lines, non-empty.

## Verified after the fixes

On the test bed (gateway + RouterOS main router + one LAN client, OSPF adjacency Full):

- **Mode A** — rule-matched domain went to the proxy, unmatched went direct (`direct` +256362 over two fetches while `proxy` moved 1080); `ip_direct` bypassed Xray entirely (both counters flat); QUIC reject caught 5/5 probes
- **Mode B** — rule-matched domain resolved to `198.18.40.147`, CN and unmatched domains to real IPs; the main router received `198.18.0.0/16` via OSPF; a client whose gateway is the main router reached it through the fake IP
- **Mode C** — 8 `/32` routes materialized from one domain rule and were published; the main router received all 8 pointing at the gateway; a client whose gateway is the main router fetched 86 KB with `proxy` +96652 and `direct` at 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
