### PR TITLE
fix: never publish a FakeIP address as an OSPF route

### DIFF
--- a/backend/fakeip_route_guard_test.go
+++ b/backend/fakeip_route_guard_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+// A FakeIP is only meaningful inside the gateway that minted it: the mapping
+// back to a domain lives in Xray's FakeDNS, which Modes A and C do not run.
+// Publishing one over OSPF points the main router at an address that resolves
+// to nothing. Observed on a live gateway after a Mode B -> C switch, where a
+// resolution in flight returned 198.18.216.7, and that /32 was persisted,
+// published, and installed on the main router while FakeDNS was already off.
+func TestFakeIPPoolIsNeverPublishable(t *testing.T) {
+	for _, raw := range []string{
+		"198.18.0.1",
+		"198.18.216.7",
+		"198.18.255.254",
+		"198.19.0.1",
+		"198.19.255.254",
+		"198.18.0.0/16",
+		"198.18.216.0/24",
+	} {
+		if got, ok := normalizeRouteKey(raw); ok {
+			t.Errorf("normalizeRouteKey(%q) = %q, publishable; a FakeIP route strands the main router", raw, got)
+		}
+	}
+}
+
+// The guard must not swallow the rest of 198/8 — 198.18.0.0/15 is the whole
+// reserved range and neighbouring space is ordinary routable unicast.
+func TestAddressesNextToTheFakeIPPoolStayPublishable(t *testing.T) {
+	for _, raw := range []string{
+		"198.17.255.254",
+		"198.20.0.1",
+		"198.51.100.1",
+		"142.251.157.119",
+	} {
+		if _, ok := normalizeRouteKey(raw); !ok {
+			t.Errorf("normalizeRouteKey(%q) rejected a routable address", raw)
+		}
+	}
+}

--- a/backend/ospf_route_state_service.go
+++ b/backend/ospf_route_state_service.go
@@ -34,6 +34,21 @@ func isDirtyRouteIPv4(ip4 net.IP, prefix int) bool {
 	if v4[0] >= 224 {
 		return true // multicast/reserved/broadcast
 	}
+	// 198.18.0.0/15 is the RFC 2544 benchmarking range, and Mode B carves its
+	// FakeDNS pool (198.18.0.0/16) out of it. A FakeIP only means anything
+	// inside the gateway that minted it: the mapping back to a domain lives in
+	// Xray's FakeDNS, which Modes A and C do not run. Publishing one over OSPF
+	// points the main router at an address nothing can resolve.
+	//
+	// This is reachable in practice. Switching Mode B -> C tears down FakeDNS
+	// and rewrites the Mosdns config, but a domain resolution already in flight
+	// can still return a pool address; it is then persisted and published, and
+	// the stale route outlives the mode it came from. Mode B publishes the pool
+	// as one static 198.18.0.0/16 route from frr.conf and never needs a /32
+	// from here, so rejecting the whole range costs nothing.
+	if v4[0] == 198 && (v4[1] == 18 || v4[1] == 19) {
+		return true // FakeIP pool / RFC 2544 benchmarking range
+	}
 	return false
 }
 


### PR DESCRIPTION
## The bug

`isDirtyRouteIPv4` rejects the default route, `0.0.0.0`, loopback, link-local and multicast before a route can reach `routes_table`. Nothing stopped an address from the **FakeDNS pool** getting through.

A FakeIP only means something inside the gateway that minted it — the mapping back to a domain lives in Xray's FakeDNS, and only Mode B runs it. Publishing one over OSPF points the main router at an address Modes A and C cannot resolve.

## It is reachable in practice

Switching Mode B → C tears down FakeDNS and rewrites the Mosdns config, but a domain resolution already in flight can still come back with a pool address. It is then persisted and published.

Observed on a live v1.7.24 gateway right after a B → C switch:

```
mode                    C
mosdns forward_fakeip   absent
xray fakedns            null
dig @127.0.0.1 www.google.com   142.251.157.119, 142.251.150.119, ...   (real)

routes_table            198.18.216.7/32  www.google.com  published
```

and on the main router:

```
DAo 198.18.216.7/32  192.168.100.199%ether2  main  110
```

## Scope, measured rather than assumed

It **does** self-heal. The next sync replaced the single fake `/32` with the eight real ones and the main router followed:

```
routes_table   142.251.150.119/32 ... 142.251.157.119/32   published, miss_count 0
ROS            8x DAo ... via 192.168.100.199, no 198.18.x
```

So this is not permanent poisoning. What it costs is one sync cycle — up to five minutes on the default `domainIPUpdater` ticker — during which the main router holds a route that the gateway cannot resolve and the rule's real addresses are not published at all, so Mode C does not work for that domain. That window lands exactly where an operator is most likely to be watching: immediately after switching modes.

## The fix

Reject `198.18.0.0/15` in `isDirtyRouteIPv4`. That is the RFC 2544 benchmarking range the pool is carved from, so nothing legitimate lives there.

Mode B publishes the pool as a **single static `198.18.0.0/16` route written into `frr.conf`**, not as `/32`s from this path, so Mode B is unaffected.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` clean. Tests cover both halves of the range as plain addresses and as CIDRs, and assert that neighbouring space (`198.17.255.254`, `198.20.0.1`, `198.51.100.1`) stays publishable so the guard does not swallow routable unicast.

Found while verifying the three modes against their documented design goals on a live deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
