### PR TITLE
fix: publish routes as soon as the mode switch lands

### DIFF
--- a/backend/mode_switch_sync_test.go
+++ b/backend/mode_switch_sync_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// waitStaticRouteSyncIdle blocks until the coalescing scheduler has drained, so
+// one subtest cannot see the previous one's goroutine.
+func waitStaticRouteSyncIdle(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		staticRouteSyncMu.Lock()
+		running, pending := staticRouteSyncRunning, staticRouteSyncPending
+		staticRouteSyncMu.Unlock()
+		if !running && !pending {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("static route sync never went idle")
+}
+
+// Publishing is otherwise driven only by domainIPUpdater's five-minute ticker.
+// Without a kick here, switching into B or C left the main router holding the
+// previous mode's routes — or none — until the next tick happened to fire, and
+// nothing surfaced that: the API reported success, every service was healthy,
+// and traffic quietly bypassed the gateway. Measured on a live gateway, a
+// client fetched 86 KB immediately after switching to C while the gateway's
+// outbound counters moved ~1 KB.
+func TestModeSwitchKicksRouteSyncForPublishingModes(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+
+	oldSync := syncStaticRoutesToOSPFFunc
+	t.Cleanup(func() {
+		syncStaticRoutesToOSPFFunc = oldSync
+		waitStaticRouteSyncIdle(t)
+	})
+
+	for _, tc := range []struct {
+		mode     string
+		wantSync bool
+	}{
+		{mode: "B", wantSync: true},
+		{mode: "C", wantSync: true},
+		{mode: "A", wantSync: false},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			waitStaticRouteSyncIdle(t)
+
+			// applyModeChange persists the new mode before running the steps,
+			// and the scheduler re-reads it from the DB, so mirror that here.
+			if _, err := db.Exec("INSERT OR REPLACE INTO settings(key, value) VALUES ('mode', ?)", tc.mode); err != nil {
+				t.Fatal(err)
+			}
+
+			got := make(chan string, 4)
+			syncStaticRoutesToOSPFFunc = func(mode string) { got <- mode }
+
+			if err := modeSwitchFinalizeRoutes(tc.mode); err != nil {
+				t.Fatalf("modeSwitchFinalizeRoutes(%s): %v", tc.mode, err)
+			}
+
+			select {
+			case m := <-got:
+				if !tc.wantSync {
+					t.Fatalf("mode %s scheduled a sync it should not have", tc.mode)
+				}
+				if m != tc.mode {
+					t.Fatalf("sync ran for mode %q, want %q", m, tc.mode)
+				}
+			case <-time.After(1 * time.Second):
+				if tc.wantSync {
+					t.Fatalf("switching to mode %s did not kick a route sync; the main router would wait for the 5-minute ticker", tc.mode)
+				}
+			}
+		})
+	}
+}
+
+// Mode C's published routes are the resolved addresses of its rules, which a
+// switch into C does not invalidate. Demoting them would withdraw working
+// routes from the main router only to re-add them moments later.
+func TestModeSwitchDemotesPublishedRoutesExceptForModeC(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+
+	oldSync := syncStaticRoutesToOSPFFunc
+	syncStaticRoutesToOSPFFunc = func(string) {}
+	t.Cleanup(func() {
+		syncStaticRoutesToOSPFFunc = oldSync
+		waitStaticRouteSyncIdle(t)
+	})
+
+	seed := func(t *testing.T) {
+		t.Helper()
+		if _, err := db.Exec("DELETE FROM routes_table"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec("INSERT INTO routes_table(ip, domain, source, status, miss_count) VALUES ('203.0.113.7/32','example.com','static','published',0)"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	statusOf := func(t *testing.T) string {
+		t.Helper()
+		var s string
+		if err := db.QueryRow("SELECT status FROM routes_table WHERE ip='203.0.113.7/32'").Scan(&s); err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+
+	t.Run("C keeps published", func(t *testing.T) {
+		seed(t)
+		if err := modeSwitchFinalizeRoutes("C"); err != nil {
+			t.Fatal(err)
+		}
+		if got := statusOf(t); got != "published" {
+			t.Fatalf("mode C demoted a published route to %q; the main router would lose it and re-learn it seconds later", got)
+		}
+	})
+
+	t.Run("A demotes", func(t *testing.T) {
+		seed(t)
+		if err := modeSwitchFinalizeRoutes("A"); err != nil {
+			t.Fatal(err)
+		}
+		if got := statusOf(t); got != "candidate" {
+			t.Fatalf("mode A left the route at %q, want candidate", got)
+		}
+	})
+}

--- a/backend/system_service.go
+++ b/backend/system_service.go
@@ -49,11 +49,28 @@ var modeSwitchApplyNftables = func() error { return applyNftablesConfig() }
 var modeSwitchApplyMosdns = func() error { return applyMosdnsConfig() }
 var modeSwitchApplyXray = func() error { return applyXrayConfig() }
 var modeSwitchFinalizeRoutes = func(mode string) error {
-	if mode == "C" {
-		return nil
+	// Mode C keeps whatever is already published: its routes are the resolved
+	// addresses of the rules, which the switch does not invalidate, and
+	// demoting them would withdraw working routes from the main router only to
+	// re-add them moments later. Every other mode starts from a clean slate.
+	if mode != "C" {
+		if _, err := getDB().Exec("UPDATE routes_table SET status='candidate' WHERE status='published'"); err != nil {
+			return err
+		}
 	}
-	_, err := getDB().Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
-	return err
+
+	// Publishing is otherwise driven solely by domainIPUpdater's five-minute
+	// ticker, so switching into B or C left the main router holding the
+	// previous mode's routes — or none at all — until the next tick happened to
+	// fire. For that window the new mode does not work and nothing says so:
+	// the API reports success, every service is healthy, and traffic quietly
+	// bypasses the gateway because the router has no reason to send it there.
+	//
+	// scheduleStaticRouteSync is asynchronous and coalesces concurrent
+	// requests, so this starts convergence without making the mode switch wait
+	// on DNS resolution of every rule. It is a no-op for Mode A.
+	scheduleStaticRouteSync(mode)
+	return nil
 }
 
 func currentMode() string {


### PR DESCRIPTION
## The bug

Publishing was driven **solely** by `domainIPUpdater`'s five-minute ticker:

```go
var modeSwitchFinalizeRoutes = func(mode string) error {
	if mode == "C" {
		return nil          // nothing scheduled
	}
	_, err := getDB().Exec("UPDATE routes_table SET status='candidate' WHERE status='published'")
	return err              // demoted, but nothing re-publishes them either
}
```

So switching into Mode B or C left the main router holding the previous mode's routes — or none at all — until the next tick happened to fire. Switching into C right after a tick means the full five minutes.

Nothing surfaces the gap. `POST /api/mode` returns `{"success":true}`, every service is healthy, `GET /api/ospf` reports the adjacency as up, and traffic simply bypasses the gateway because the main router has no reason to send it there.

Measured on a live gateway immediately after switching to Mode C:

```
routes_table   0 rows
/api/ospf      {"neighbors":1,"pending":0,"published":0}
ROS            no OSPF routes

client (default gateway = main router) fetched 86 KB from a rule-matched domain
gateway counters moved ~1 KB
```

The window lands exactly where an operator is most likely to be looking — right after flipping the mode — which makes it read as "Mode C is broken" rather than "Mode C has not converged yet".

## The fix

Kick `scheduleStaticRouteSync` from the finalize step. It is asynchronous and coalesces concurrent requests, so the switch starts convergence without waiting on DNS resolution of every rule, and it already returns immediately for Mode A.

Mode C still keeps its published routes rather than demoting them: those are the resolved addresses of its rules, which the switch does not invalidate, so demoting would withdraw working routes from the main router only to re-add them moments later. That asymmetry was previously implicit in an early `return nil`; it is now explicit and has a test.

## Verification

Built and deployed to the gateway the bug was measured on, then switched C → A → C:

```
start (Mode C)     published = 8
switch to A        published = 0        (demoted, as expected)
switch back to C   published = 8 after 1 second
```

The main router picked all eight `/32`s straight back up, and a client whose default gateway is the main router fetched 86 KB with `proxy-1-out` +95256 and `direct` at 0.

`go build ./...`, `go vet ./...`, `go test ./...` clean. New tests cover that B and C schedule a sync while A does not, and that C alone keeps its published routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
