### PR TITLE
fix: let the unit write the sysctl tree disableSendRedirects targets

### DIFF
--- a/backend/unit_sandbox_test.go
+++ b/backend/unit_sandbox_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// disableSendRedirects writes into /proc/sys/net/ipv4/conf, but the unit sets
+// ProtectKernelTunables=yes, which mounts /proc/sys read-only. Without an
+// explicit ReadWritePaths entry every write fails with "read-only file system"
+// and the gateway keeps emitting the ICMP redirects that let clients bypass
+// Mode A — the install-time loop only fixes it once, and interfaces are
+// recreated on every boot.
+func TestUnitGrantsWriteAccessToTheSysctlTreeTheBackendWrites(t *testing.T) {
+	for _, f := range []string{
+		"../systemd/proxygw.service",
+		"../scripts/install.sh",
+		"../scripts/update.sh",
+	} {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("%s: %v", f, err)
+		}
+		body := string(b)
+
+		var rwp string
+		for _, line := range strings.Split(body, "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "ReadWritePaths=") {
+				rwp = line
+				break
+			}
+		}
+		if rwp == "" {
+			t.Fatalf("%s has no ReadWritePaths line", f)
+		}
+		if !strings.Contains(rwp, ipv4ConfDir) {
+			t.Errorf("%s does not grant %s:\n  %s\ndisableSendRedirects would fail read-only and Mode A stays bypassable", f, ipv4ConfDir, rwp)
+		}
+	}
+}
+
+// The path the unit grants and the path the code writes have to be the same
+// one; a rename on either side would silently re-break it.
+func TestSysctlWritePathMatchesWhatTheCodeUses(t *testing.T) {
+	if filepath.Clean(ipv4ConfDir) != "/proc/sys/net/ipv4/conf" {
+		t.Fatalf("ipv4ConfDir is %q; update the unit's ReadWritePaths to match", ipv4ConfDir)
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -191,7 +191,7 @@ PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes
 RestrictSUIDSGID=yes
-ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf
+ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf /proc/sys/net/ipv4/conf
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -105,7 +105,7 @@ PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes
 RestrictSUIDSGID=yes
-ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf
+ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf /proc/sys/net/ipv4/conf
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/proxygw.service
+++ b/systemd/proxygw.service
@@ -19,7 +19,7 @@ PrivateTmp=yes
 ProtectKernelTunables=yes
 ProtectControlGroups=yes
 RestrictSUIDSGID=yes
-ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf
+ReadWritePaths=-/root/proxygw -/usr/local/bin -/etc/frr -/etc/nftables.conf /proc/sys/net/ipv4/conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Follow-up to #31, which is half-dead as shipped in v1.7.24.

## The bug

`disableSendRedirects` writes into `/proc/sys/net/ipv4/conf`, but the unit sets `ProtectKernelTunables=yes`, which mounts `/proc/sys` read-only. Every write fails:

```
[WARN] failed to disable send_redirects on all: open /proc/sys/net/ipv4/conf/all/send_redirects: read-only file system
[WARN] failed to disable send_redirects on default: ... read-only file system
[WARN] failed to disable send_redirects on eth0: ... read-only file system
[WARN] failed to disable send_redirects on lo: ... read-only file system
```

This is the same shape as #27: a path the backend has to write, blocked by the sandbox, failing per-call instead of once.

## Why a fresh install still looked correct

The install-time loop #31 also added runs as root **outside** the unit sandbox, so it works — `eth0 send_redirects` really is 0 after `install.sh`. But it only covers the interfaces that exist at install time.

Interfaces are recreated on every boot, and `conf.default` does not retroactively cover one that already exists when `systemd-sysctl` applies the drop-in — which is the original bug #31 was about. So after a reboot the gateway goes back to emitting the redirects that let clients bypass Mode A, and the one component that would have re-fixed it cannot write.

## The fix

Grant `/proc/sys/net/ipv4/conf` in `ReadWritePaths`, in all three places that write the unit (`systemd/proxygw.service`, `scripts/install.sh`, `scripts/update.sh`).

Verified on a live gateway: with the entry added and the service restarted, the read-only warnings go to zero and `eth0` stays at 0.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...` clean.

The tests tie the unit's grant to the constant the code writes, in all three files, so a rename on either side cannot silently re-break it — which is exactly how this survived review the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
