### PR TITLE
chore: remove dead code flagged by staticcheck

### DIFF
--- a/backend/app_controller.go
+++ b/backend/app_controller.go
@@ -9,15 +9,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// respondError logs the real error server-side and returns a generic message to the client.
-// Use this for all "something went wrong" responses where we don't want to leak internals.
-func respondError(c *gin.Context, status int, err error, contextMsg string) {
-	if err != nil {
-		log.Printf("[ERR] %s: %v", contextMsg, err)
-	}
-	c.JSON(status, gin.H{"error": contextMsg})
-}
-
 // AppController encapsulates HTTP route wiring and server lifecycle.
 type AppController struct{}
 
@@ -59,7 +50,6 @@ func (c *AppController) Run(r *gin.Engine) {
 	log.Printf("EdgeRouteGW backend starting on %s", addr)
 	r.Run(addr)
 }
-
 
 func init() {
 	os.Setenv("TZ", "Asia/Shanghai")

--- a/backend/connection_tracker.go
+++ b/backend/connection_tracker.go
@@ -421,34 +421,6 @@ func attachRuleMatchMeta(records []ConnectionRecord) []ConnectionRecord {
 	return records
 }
 
-func serviceNetworkCIDR() *net.IPNet {
-	ensureDefaultNetworkRoleSettings()
-	_, subnet := getPrimaryLANIPAndSubnet()
-	if strings.TrimSpace(subnet) == "" {
-		return nil
-	}
-	_, cidr, err := net.ParseCIDR(strings.TrimSpace(subnet))
-	if err != nil {
-		return nil
-	}
-	return cidr
-}
-
-func clientIPFromConnClient(client string) net.IP {
-	host := strings.TrimSpace(client)
-	if host == "" {
-		return nil
-	}
-	if strings.Contains(host, ":") {
-		if h, _, err := net.SplitHostPort(host); err == nil {
-			host = strings.Trim(h, "[]")
-		} else if idx := strings.LastIndex(host, ":"); idx > 0 {
-			host = strings.Trim(host[:idx], "[]")
-		}
-	}
-	return net.ParseIP(strings.TrimSpace(host))
-}
-
 func registerConnectionRoutes(r *gin.RouterGroup) {
 	r.GET("/connections", func(c *gin.Context) {
 		ip := c.Query("ip")

--- a/backend/cron_domain_service.go
+++ b/backend/cron_domain_service.go
@@ -159,10 +159,6 @@ func cronUpdater() {
 	}
 }
 
-func scheduleApply() {
-	scheduleApplyWithMosdns(false)
-}
-
 func scheduleApplyWithMosdns(needMosdns bool) {
 	applyMutex.Lock()
 	defer applyMutex.Unlock()

--- a/backend/geo_query.go
+++ b/backend/geo_query.go
@@ -631,24 +631,6 @@ func queryGeoIPBestCIDRsByIP(filename, input string) []string {
 	return cidrs
 }
 
-func matchGeoSiteDomain(domain string, entry geoSiteDomainEntry) bool {
-	domain = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(domain)), ".")
-	value := strings.TrimSuffix(strings.ToLower(strings.TrimSpace(entry.Value)), ".")
-	switch entry.Type {
-	case "full":
-		return domain == value
-	case "domain":
-		return domain == value || strings.HasSuffix(domain, "."+value)
-	case "keyword":
-		return strings.Contains(domain, value)
-	case "regex":
-		matched, err := regexp.MatchString(value, domain)
-		return err == nil && matched
-	default:
-		return false
-	}
-}
-
 func scanGeoSiteEntries(filename string, fn func(tag string, entries []geoSiteDomainEntry)) {
 	_ = scanGeoSiteEntriesE(filename, fn)
 }

--- a/backend/ospf_dns_cache.go
+++ b/backend/ospf_dns_cache.go
@@ -61,36 +61,6 @@ const (
 	resolverGroupLocal  = "local"
 )
 
-var hostLookupCommand = func(domain string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), domainResolveTimeout)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, "host", "-t", "A", "-v", domain).CombinedOutput()
-	if ctx.Err() == context.DeadlineExceeded {
-		return string(out), fmt.Errorf("host lookup timeout for %q after %s", domain, domainResolveTimeout)
-	}
-	if err != nil {
-		return string(out), err
-	}
-	return string(out), nil
-}
-
-var hostLookupCommandAtServer = func(domain string, server string) (string, error) {
-	args := []string{"-t", "A", "-v", domain}
-	if normalized, ok := normalizeDNSServerAddr(server); ok {
-		args = append(args, normalized)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), domainResolveTimeout)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, "host", args...).CombinedOutput()
-	if ctx.Err() == context.DeadlineExceeded {
-		return string(out), fmt.Errorf("host lookup timeout for %q via %q after %s", domain, server, domainResolveTimeout)
-	}
-	if err != nil {
-		return string(out), err
-	}
-	return string(out), nil
-}
-
 var answerSectionARecordPattern = regexp.MustCompile(`^\S+\.\s+(\d+)\s+IN\s+A\s+((?:\d{1,3}\.){3}\d{1,3})\s*$`)
 
 func parseHostLookupOutput(output string) ([]string, int, error) {
@@ -153,17 +123,6 @@ func normalizeDNSServerAddr(server string) (string, bool) {
 		}
 	}
 	return server, true
-}
-
-func parseDNSServerList(raw string) []string {
-	items := strings.Split(raw, ",")
-	servers := make([]string, 0, len(items))
-	for _, item := range items {
-		if normalized, ok := normalizeDNSServerAddr(item); ok {
-			servers = append(servers, normalized)
-		}
-	}
-	return servers
 }
 
 func normalizeResolverGroup(group string) string {

--- a/backend/wireguard_service.go
+++ b/backend/wireguard_service.go
@@ -22,9 +22,7 @@ func cleanupTransientWireguardInterfaces() {
 			continue
 		}
 		ifName := fields[1]
-		if strings.HasSuffix(ifName, ":") {
-			ifName = strings.TrimSuffix(ifName, ":")
-		}
+		ifName = strings.TrimSuffix(ifName, ":")
 		cidr := fields[3]
 		if !strings.HasSuffix(cidr, "/32") {
 			continue


### PR DESCRIPTION
`staticcheck ./...` on `main` reports 14 findings. This clears the mechanical ones.

## Removed (U1000 — unreferenced)

| Symbol | File |
|---|---|
| `respondError` | `app_controller.go` |
| `serviceNetworkCIDR` | `connection_tracker.go` |
| `clientIPFromConnClient` | `connection_tracker.go` |
| `scheduleApply` | `cron_domain_service.go` |
| `matchGeoSiteDomain` | `geo_query.go` |
| `hostLookupCommand` | `ospf_dns_cache.go` |
| `hostLookupCommandAtServer` | `ospf_dns_cache.go` |
| `parseDNSServerList` | `ospf_dns_cache.go` |

The last three are remnants of the `host`-based resolver that 1.7.20 deliberately replaced with `dig`. Leaving them in the tree implies a fallback path that does not exist — which is exactly the kind of misreading that hid #32 for so long.

## Also

- S1017: `HasSuffix` + `TrimSuffix` → unconditional `TrimSuffix` in `wireguard_service.go`
- `app_controller.go` was the one non-test file `gofmt -l` still flagged; goimports settled it while fixing imports

## Deliberately not touched

The two ST1005 findings (error-string capitalisation/punctuation in `remote_deploy/ssh_helper.go`). Those strings are shown to the operator and one is matched verbatim by `remote_node_mock_test.go`. Not worth a behaviour risk for a style nit.

The two SA1019 findings (deprecated CFB mode in `crypto_utils.go`) are a real security item and get their own PR.

## Verification

`go build`, `go vet`, `go test ./...` clean. `staticcheck` now reports only SA1019 ×2 and ST1005 ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
