### PR TITLE
security: close four gaps found in the audit

### DIFF
--- a/backend/crypto_utils.go
+++ b/backend/crypto_utils.go
@@ -45,8 +45,11 @@ func init() {
 		// decryptable from source.
 		aesKey = make([]byte, 32)
 		if _, err := io.ReadFull(rand.Reader, aesKey); err != nil {
-			log.Printf("[CRITICAL] failed to generate AES key: %v", err)
-			aesKey = append([]byte(nil), legacyAESKey...)
+			// Falling back to the well-known legacy constant would encrypt
+			// every SSH credential written this session with a key that is in
+			// the public source tree, and persist it below. Refusing to start is
+			// the only safe answer to a CSPRNG failure.
+			log.Fatalf("[CRITICAL] failed to generate AES key, refusing to start: %v", err)
 		}
 		if err := os.WriteFile(keyPath, aesKey, 0600); err != nil {
 			log.Printf("[SECURITY] failed to persist AES key: %v", err)

--- a/backend/hardening_guards_test.go
+++ b/backend/hardening_guards_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// The guard and the lock both short-circuit in gin.TestMode, so the tests
+// that exercise them have to leave it.
+func withReleaseMode(t *testing.T) {
+	t.Helper()
+	old := gin.Mode()
+	gin.SetMode(gin.ReleaseMode)
+	t.Cleanup(func() { gin.SetMode(old) })
+}
+
+func newGuardTestCtx(method, target string) (*gin.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(method, target, nil)
+	return c, w
+}
+
+func TestHighRiskLockGroupSharesConfigWriters(t *testing.T) {
+	for _, a := range []string{"apply_config", "mode_switch", "network_config"} {
+		if g := highRiskLockGroup(a); g != "config_writers" {
+			t.Errorf("%s -> %q, want config_writers", a, g)
+		}
+	}
+	for _, a := range []string{"ospf_settings", "ospf_reset_pending", "hostkey_repin"} {
+		if g := highRiskLockGroup(a); g != a {
+			t.Errorf("%s -> %q, want a lock of its own", a, g)
+		}
+	}
+}
+
+// apply_config and mode_switch both regenerate the Xray, Mosdns and nftables
+// configs, and neither applyMosdnsConfig nor applyNftablesConfig has a lock of
+// its own. A per-action lock let the two run concurrently and interleave their
+// writes to the same files.
+func TestConfigWritersExcludeEachOther(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	withReleaseMode(t)
+
+	c1, _ := newGuardTestCtx(http.MethodPost, "/api/mode")
+	release, ok := tryAcquireHighRiskMutationLock(c1, "mode_switch")
+	if !ok {
+		t.Fatal("first acquire failed")
+	}
+	defer release()
+
+	c2, w2 := newGuardTestCtx(http.MethodPost, "/api/apply")
+	if _, ok := tryAcquireHighRiskMutationLock(c2, "apply_config"); ok {
+		t.Fatal("apply_config acquired while mode_switch was in flight; they write the same files")
+	}
+	if w2.Code != http.StatusConflict || !strings.Contains(w2.Body.String(), "HIGH_RISK_ACTION_BUSY") {
+		t.Fatalf("want 409 HIGH_RISK_ACTION_BUSY, got %d %s", w2.Code, w2.Body.String())
+	}
+
+	// Unrelated actions must not be caught by the shared group.
+	c3, _ := newGuardTestCtx(http.MethodPost, "/api/remote_nodes/1/hostkey")
+	rel3, ok := tryAcquireHighRiskMutationLock(c3, "hostkey_repin")
+	if !ok {
+		t.Fatal("hostkey_repin was blocked by the config_writers group")
+	}
+	rel3()
+}
+
+func TestLockReleaseFreesTheGroup(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	withReleaseMode(t)
+
+	c1, _ := newGuardTestCtx(http.MethodPost, "/api/mode")
+	release, ok := tryAcquireHighRiskMutationLock(c1, "mode_switch")
+	if !ok {
+		t.Fatal("acquire")
+	}
+	release()
+
+	c2, _ := newGuardTestCtx(http.MethodPost, "/api/apply")
+	rel2, ok := tryAcquireHighRiskMutationLock(c2, "apply_config")
+	if !ok {
+		t.Fatal("group still held after release")
+	}
+	rel2()
+}
+
+// dig has no "--" terminator, so a name that starts with '-', '+' or '@' is
+// an option, a query flag or a server. The validators upstream reject such
+// values, but this is the single place a string is handed to a root-run
+// subprocess, so it must refuse on its own.
+func TestDigRefusesOptionLikeNames(t *testing.T) {
+	for _, name := range []string{"-f/etc/passwd", "+trace", "@127.0.0.1", "-", ""} {
+		_, err := lookupIPv4WithDNSServer(name, "127.0.0.1", false)
+		if err == nil || !strings.Contains(err.Error(), "option-like") {
+			t.Errorf("%q: got err=%v, want a refusal before dig is invoked", name, err)
+		}
+	}
+}
+
+// After a re-pin, deploy and check will authenticate to whatever presents
+// the new key. That is the one operation that can silently redirect stored
+// SSH credentials, and it must not be a bare authenticated POST.
+func TestHostKeyRepinRequiresConfirmToken(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+	withReleaseMode(t)
+
+	c, w := newGuardTestCtx(http.MethodPost, "/api/remote_nodes/1/hostkey")
+	c.Params = gin.Params{{Key: "id", Value: "1"}}
+	updateRemoteNodeHostKey(c)
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), "HIGH_RISK_CONFIRM_REQUIRED") {
+		t.Fatalf("re-pin without confirm token: got %d %s, want 403 HIGH_RISK_CONFIRM_REQUIRED", w.Code, w.Body.String())
+	}
+
+	c2, w2 := newGuardTestCtx(http.MethodPost, "/api/remote_nodes/1/hostkey?confirm=APPLY")
+	c2.Params = gin.Params{{Key: "id", Value: "1"}}
+	updateRemoteNodeHostKey(c2)
+	if w2.Code == http.StatusForbidden {
+		t.Fatalf("confirm token not honoured: %d %s", w2.Code, w2.Body.String())
+	}
+}

--- a/backend/ospf_dns_cache.go
+++ b/backend/ospf_dns_cache.go
@@ -150,6 +150,15 @@ func lookupIPv4WithDNSServer(domain string, server string, _ bool) ([]string, er
 		return nil, fmt.Errorf("invalid dns server %q", server)
 	}
 
+	// dig has no "--" terminator: anything that starts with '-', '+' or '@' is
+	// parsed as an option, a query flag or a server, not as a name. The rule
+	// validators upstream already reject such values, but this is the one
+	// place that hands a string to a root-run subprocess, so refuse here too
+	// rather than trust every caller forever.
+	if domain == "" || strings.ContainsAny(domain[:1], "-+@") {
+		return nil, fmt.Errorf("refusing to pass option-like name %q to dig", domain)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), domainResolveTimeout)
 	defer cancel()
 

--- a/backend/remote_nodes_controller.go
+++ b/backend/remote_nodes_controller.go
@@ -189,6 +189,13 @@ func isValidSSHHostKeyFingerprint(s string) bool {
 // for a legitimately rotated host key: instead of silently auto-trusting, the
 // operator verifies the new fingerprint out-of-band and submits it here.
 func updateRemoteNodeHostKey(c *gin.Context) {
+	// Re-pinning is the one operation that can silently redirect SSH
+	// credentials to a different machine: after it, deploy and check will
+	// happily authenticate to whatever presents the new key. Deploy, mode
+	// switch and apply all require the confirm token; this must too.
+	if !requireHighRiskMutationGuard(c, "hostkey_repin") {
+		return
+	}
 	id := c.Param("id")
 	var req struct {
 		SSHHostKey string `json:"ssh_host_key"`

--- a/backend/system_service.go
+++ b/backend/system_service.go
@@ -160,12 +160,27 @@ var (
 	highRiskMutationInFlight = map[string]bool{}
 )
 
+// highRiskLockGroup maps an action to the lock it contends on. Actions that
+// rewrite the same runtime files must exclude each other, not just themselves:
+// apply_config and mode_switch both regenerate the Xray, Mosdns and nftables
+// configs and neither applyMosdnsConfig nor applyNftablesConfig has any lock
+// of its own, so a per-action lock let an /api/apply and an /api/mode race and
+// interleave their writes. Everything else keeps a lock of its own.
+func highRiskLockGroup(action string) string {
+	switch action {
+	case "apply_config", "mode_switch", "network_config":
+		return "config_writers"
+	}
+	return action
+}
+
 func tryAcquireHighRiskMutationLock(c *gin.Context, action string) (func(), bool) {
 	if gin.Mode() == gin.TestMode {
 		return func() {}, true
 	}
+	group := highRiskLockGroup(action)
 	highRiskMutationLockMu.Lock()
-	if highRiskMutationInFlight[action] {
+	if highRiskMutationInFlight[group] {
 		highRiskMutationLockMu.Unlock()
 		path := c.FullPath()
 		if path == "" {
@@ -185,11 +200,11 @@ func tryAcquireHighRiskMutationLock(c *gin.Context, action string) (func(), bool
 		})
 		return nil, false
 	}
-	highRiskMutationInFlight[action] = true
+	highRiskMutationInFlight[group] = true
 	highRiskMutationLockMu.Unlock()
 	return func() {
 		highRiskMutationLockMu.Lock()
-		delete(highRiskMutationInFlight, action)
+		delete(highRiskMutationInFlight, group)
 		highRiskMutationLockMu.Unlock()
 	}, true
 }


### PR DESCRIPTION
Four small, independent hardening changes from a full audit pass. Each is a few lines; grouped because they share the theme "a boundary that looked guarded but wasn't".

## 1. `dig` argument injection — refuse at the sink

`ospf_dns_cache.go` runs `dig +short ... @server <domain>`. `dig` has no `--` terminator, so a name starting with `-`, `+` or `@` is parsed as an option (`-f` reads a batch file), a query flag or a server. The domain-rule validator's label regex already rejects those characters, so this is **defense in depth**, not a live exploit — but it is the one place a string reaches a root-run subprocess, and validators upstream change. Refuse `-`/`+`/`@`-prefixed and empty names before `exec`.

## 2. AES key generation — fail closed

If `rand.Reader` failed, `init()` fell back to `legacyAESKey` — the constant that lives in the public source tree — **and persisted it as the key**. Every SSH credential written that session would be decryptable from GitHub. Now it `log.Fatalf`s. A healthy host never takes this branch; a broken one must not start.

## 3. Host-key re-pin — require the confirm token

`POST /remote_nodes/:id/hostkey` replaces the pinned SSH host key. After that, deploy and health-check will authenticate to whatever presents the new key, so it is the single call that can silently redirect stored credentials to another machine. Deploy, mode switch, apply and OSPF settings all require `X-EdgeRouteGW-Confirm: APPLY` / `?confirm=APPLY`; this did not. It does now.

Checked the built frontend: it never calls this endpoint (it is the documented API-only recovery path), so no UI change is needed.

## 4. Mutation lock — group the config writers

`tryAcquireHighRiskMutationLock` was keyed per action. But `apply_config` and `mode_switch` both regenerate the Xray, Mosdns and nftables configs, and `applyMosdnsConfig` / `applyNftablesConfig` have no lock of their own — so `/api/apply` and `/api/mode` could run concurrently and interleave writes to the same files. They (and `network_config`) now share one `config_writers` group; everything else keeps its own lock, so a multi-minute remote deploy still does not block a mode switch.

## Not done, deliberately

`POST /update/:component` replaces the root-run Xray/Mosdns binaries and is at least as high-risk as `apply` — but the built frontend calls it **without** the confirm token, so guarding it would break the update buttons. Needs a frontend change first.

## Verification

`go build`, `go vet`, `go test ./...` clean. New tests run the guard and the lock outside `gin.TestMode` (both short-circuit inside it) and cover: the lock group mapping; `apply_config` rejected with 409 while `mode_switch` is in flight; unrelated actions unaffected; release frees the group; option-like names refused before `dig`; re-pin 403 without the token and past the guard with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
