### PR TITLE
release: publish SHA256SUMS and verify the backend binary before installing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,12 @@ jobs:
           CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -o proxygw-backend-linux-amd64 .
           CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-gnu-gcc go build -o proxygw-backend-linux-arm64 .
 
+      - name: Generate checksums
+        run: |
+          cd backend
+          sha256sum proxygw-backend-linux-amd64 proxygw-backend-linux-arm64 > SHA256SUMS
+          cat SHA256SUMS
+
       - name: Extract release notes from changelog
         shell: bash
         run: |
@@ -54,3 +60,4 @@ jobs:
           files: |
             backend/proxygw-backend-linux-amd64
             backend/proxygw-backend-linux-arm64
+            backend/SHA256SUMS

--- a/backend/release_checksums_test.go
+++ b/backend/release_checksums_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The backend binary runs as root. install.sh and update.sh fetch it from
+// GitHub and execute it; until now nothing checked that what arrived is what
+// the release workflow built. These pin the three parts that have to agree:
+// the workflow publishes SHA256SUMS, and both scripts verify against it and
+// abort on a mismatch.
+func TestReleaseWorkflowPublishesChecksums(t *testing.T) {
+	b, err := os.ReadFile("../.github/workflows/release.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{
+		"sha256sum proxygw-backend-linux-amd64 proxygw-backend-linux-arm64 > SHA256SUMS",
+		"backend/SHA256SUMS",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("release.yml missing %q; install.sh/update.sh would find nothing to verify against", want)
+		}
+	}
+}
+
+func TestBackendBinaryDownloadsAreChecksumVerified(t *testing.T) {
+	for _, f := range []string{"../scripts/install.sh", "../scripts/update.sh"} {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("%s: %v", f, err)
+		}
+		s := string(b)
+		if !strings.Contains(s, "verify_backend_checksum()") {
+			t.Errorf("%s does not define verify_backend_checksum", f)
+		}
+		// Defined is not enough; it has to run on the downloaded file and a
+		// failure has to stop the script before the binary is installed.
+		if !strings.Contains(s, "verify_backend_checksum \"") || !strings.Contains(s, "\"$PROXYGW_LATEST\" || exit 1") {
+			t.Errorf("%s does not call verify_backend_checksum fail-closed on the downloaded binary", f)
+		}
+		if !strings.Contains(s, "releases/download/${tag}/SHA256SUMS") {
+			t.Errorf("%s does not fetch SHA256SUMS from the release", f)
+		}
+	}
+}

--- a/scripts/check-release-chain.sh
+++ b/scripts/check-release-chain.sh
@@ -36,6 +36,11 @@ if ! grep -q 'name: EdgeRouteGW \${{ github.ref_name }} Stable' "$RELEASE_YML" \
   exit 1
 fi
 
+grep -q 'backend/SHA256SUMS' "$RELEASE_YML" || {
+  echo "failed: release workflow does not publish SHA256SUMS; install.sh/update.sh verify against it"
+  exit 1
+}
+
 grep -q 'body_path: /tmp/release_notes.md' "$RELEASE_YML" || {
   echo "failed: release workflow missing changelog-driven notes"
   exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,11 +160,41 @@ if [ -z "$PROXYGW_LATEST" ]; then
     echo "Warning: API blocked. Using fallback version v1.7.26..."
     PROXYGW_LATEST="v1.7.26"
 fi
+
+# verify_backend_checksum FILE ASSET_NAME TAG
+# Releases publish SHA256SUMS next to the binaries. A mismatch is fatal: the
+# file is a root-executed binary and a bad byte is worse than no update. A
+# missing SHA256SUMS is only a warning, because tags older than the one that
+# introduced it (and the hardcoded offline fallback tag) never had one.
+verify_backend_checksum() {
+    local file="$1" asset="$2" tag="$3"
+    local sums; sums=$(mktemp)
+    if ! ${DOWNLOAD_CMD:-wget -q -4 -O} "$sums" "https://github.com/zlylong/EdgeRouteGW/releases/download/${tag}/SHA256SUMS" 2>/dev/null || [ ! -s "$sums" ]; then
+        echo "Warning: no SHA256SUMS published for ${tag}; skipping verification"
+        rm -f "$sums"; return 0
+    fi
+    local want; want=$(awk -v a="$asset" '$2==a {print $1}' "$sums")
+    rm -f "$sums"
+    if [ -z "$want" ]; then
+        echo "Error: SHA256SUMS for ${tag} has no entry for ${asset}"; return 1
+    fi
+    local got; got=$(sha256sum "$file" | awk '{print $1}')
+    if [ "$want" != "$got" ]; then
+        echo "Error: checksum mismatch for ${asset} (${tag})"
+        echo "  expected ${want}"
+        echo "  got      ${got}"
+        rm -f "$file"; return 1
+    fi
+    echo "Checksum verified for ${asset} (${tag})"
+}
+
 if [ "$ARCH" = "x86_64" ]; then
-    wget -q -4 -O "$REPO_DIR/backend/proxygw-backend" "https://github.com/zlylong/EdgeRouteGW/releases/download/${PROXYGW_LATEST}/proxygw-backend-linux-amd64"
+    BACKEND_ASSET="proxygw-backend-linux-amd64"
 elif [ "$ARCH" = "aarch64" ]; then
-    wget -q -4 -O "$REPO_DIR/backend/proxygw-backend" "https://github.com/zlylong/EdgeRouteGW/releases/download/${PROXYGW_LATEST}/proxygw-backend-linux-arm64"
+    BACKEND_ASSET="proxygw-backend-linux-arm64"
 fi
+wget -q -4 -O "$REPO_DIR/backend/proxygw-backend" "https://github.com/zlylong/EdgeRouteGW/releases/download/${PROXYGW_LATEST}/${BACKEND_ASSET}"
+verify_backend_checksum "$REPO_DIR/backend/proxygw-backend" "$BACKEND_ASSET" "$PROXYGW_LATEST" || exit 1
 chmod +x "$REPO_DIR/backend/proxygw-backend"
 
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -69,11 +69,41 @@ if [ -z "$PROXYGW_LATEST" ]; then
 fi
 
 echo "Using release tag: $PROXYGW_LATEST"
+
+# verify_backend_checksum FILE ASSET_NAME TAG
+# Releases publish SHA256SUMS next to the binaries. A mismatch is fatal: the
+# file is a root-executed binary and a bad byte is worse than no update. A
+# missing SHA256SUMS is only a warning, because tags older than the one that
+# introduced it (and the hardcoded offline fallback tag) never had one.
+verify_backend_checksum() {
+    local file="$1" asset="$2" tag="$3"
+    local sums; sums=$(mktemp)
+    if ! ${DOWNLOAD_CMD:-wget -q -4 -O} "$sums" "https://github.com/zlylong/EdgeRouteGW/releases/download/${tag}/SHA256SUMS" 2>/dev/null || [ ! -s "$sums" ]; then
+        echo "Warning: no SHA256SUMS published for ${tag}; skipping verification"
+        rm -f "$sums"; return 0
+    fi
+    local want; want=$(awk -v a="$asset" '$2==a {print $1}' "$sums")
+    rm -f "$sums"
+    if [ -z "$want" ]; then
+        echo "Error: SHA256SUMS for ${tag} has no entry for ${asset}"; return 1
+    fi
+    local got; got=$(sha256sum "$file" | awk '{print $1}')
+    if [ "$want" != "$got" ]; then
+        echo "Error: checksum mismatch for ${asset} (${tag})"
+        echo "  expected ${want}"
+        echo "  got      ${got}"
+        rm -f "$file"; return 1
+    fi
+    echo "Checksum verified for ${asset} (${tag})"
+}
+
 if [ "$ARCH" = "x86_64" ]; then
-    http_proxy="$UPDATE_HTTP_PROXY" https_proxy="$UPDATE_HTTPS_PROXY" wget -q -4 -O "$TMP_BACKEND" "https://github.com/zlylong/EdgeRouteGW/releases/download/${PROXYGW_LATEST}/proxygw-backend-linux-amd64"
+    BACKEND_ASSET="proxygw-backend-linux-amd64"
 elif [ "$ARCH" = "aarch64" ]; then
-    http_proxy="$UPDATE_HTTP_PROXY" https_proxy="$UPDATE_HTTPS_PROXY" wget -q -4 -O "$TMP_BACKEND" "https://github.com/zlylong/EdgeRouteGW/releases/download/${PROXYGW_LATEST}/proxygw-backend-linux-arm64"
+    BACKEND_ASSET="proxygw-backend-linux-arm64"
 fi
+http_proxy="$UPDATE_HTTP_PROXY" https_proxy="$UPDATE_HTTPS_PROXY" wget -q -4 -O "$TMP_BACKEND" "https://github.com/zlylong/EdgeRouteGW/releases/download/${PROXYGW_LATEST}/${BACKEND_ASSET}"
+DOWNLOAD_CMD="env http_proxy=$UPDATE_HTTP_PROXY https_proxy=$UPDATE_HTTPS_PROXY wget -q -4 -O" verify_backend_checksum "$TMP_BACKEND" "$BACKEND_ASSET" "$PROXYGW_LATEST" || exit 1
 chmod +x "$TMP_BACKEND"
 
 # Now that downloads are complete, stop the service to perform the swap and sync


### PR DESCRIPTION
## The gap

`install.sh` and `update.sh` download `proxygw-backend` from GitHub Releases with `wget` and run it **as root**. Nothing checked that the bytes that arrived were the bytes the workflow built. A truncated transfer, a proxy substituting content, or a tampered asset all install the same way. (The in-app updater already verifies Xray and Mosdns against published hashes; the backend itself was the exception.)

## The change

**`release.yml`** — writes `SHA256SUMS` next to the two binaries and publishes it as a third asset.

**`install.sh` / `update.sh`** — after downloading the binary, fetch `SHA256SUMS` for the same tag, compare the entry for the asset, and on a mismatch or missing entry **abort and delete the file** (`|| exit 1`, and both scripts already run `set -euo pipefail`).

**Backward compatibility** — a release with no `SHA256SUMS` at all (every tag up to and including v1.7.26, plus the hardcoded offline-fallback tag) only warns and continues. Fail-closed on a bad checksum; fail-open only on the file being absent. That keeps every existing install path working until the first release built with this workflow.

**`check-release-chain.sh`** — also fails if the workflow ever stops publishing the sums file, since the scripts would silently downgrade to unverified.

## What this does and does not protect against

It protects against corruption in transit and against any path where the binary and the sums file can be altered independently. It does **not** protect against a full compromise of the release pipeline, which could republish both — that needs signing, which needs key management and is out of scope here.

## Verification

Exercised the shell function directly:

| case | result |
|---|---|
| matching sums | `Checksum verified`, rc=0 |
| wrong hash | `checksum mismatch`, rc=1, file removed |
| sums present but no entry for the asset | rc=1 |
| v1.7.26 (no sums published) | warning, rc=0 |

Go tests pin the three parts that must agree (workflow publishes, both scripts verify fail-closed). `check-release-chain.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
