### PR TITLE
security: stop git from replacing the per-install AES key on every update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ config/*.db*
 # Coverage output
 coverage/
 backend/coverage.out
+
+# Per-install secrets: generated on first boot, must never be committed or reset by git
+/config/aes.key
+/config/aes.rotation_pending

--- a/backend/aes_key_untracked_test.go
+++ b/backend/aes_key_untracked_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// config/aes.key is written by init() on first boot and is the only copy of
+// the key every stored SSH credential is encrypted with. While it was a
+// tracked file, update.sh's "git reset --hard origin/main" put the committed
+// placeholder back over it on every update, and every credential became
+// undecryptable on the next start.
+func TestAESKeyIsNeitherTrackedNorResettable(t *testing.T) {
+	ig, err := os.ReadFile("../.gitignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"/config/aes.key", "/config/aes.rotation_pending"} {
+		if !strings.Contains(string(ig), want+"\n") {
+			t.Errorf(".gitignore does not list %s; a checkout would track a per-install secret again", want)
+		}
+	}
+
+	up, err := os.ReadFile("../scripts/update.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(up)
+	reset := strings.Index(s, "git reset --hard origin/main")
+	backup := strings.Index(s, `cp -p "$REPO_DIR/config/aes.key" "$AES_KEY_BACKUP"`)
+	restore := strings.Index(s, `cp -p "$AES_KEY_BACKUP" "$REPO_DIR/config/aes.key"`)
+	if reset < 0 || backup < 0 || restore < 0 {
+		t.Fatalf("update.sh must back up config/aes.key before git reset --hard and restore it after (reset=%d backup=%d restore=%d)", reset, backup, restore)
+	}
+	if !(backup < reset && reset < restore) {
+		t.Fatalf("update.sh key backup/restore is not wrapped around git reset --hard (backup=%d reset=%d restore=%d)", backup, reset, restore)
+	}
+}
+
+// Preserving an undecryptable row is right for the data and wrong for the
+// operator, who would otherwise learn about it when a deploy fails to
+// authenticate. It has to be said, once, with the cause and the remedy.
+func TestMigrateReportsUndecryptableCredentialsLoudly(t *testing.T) {
+	_, restore := newTestDB(t)
+	defer restore()
+
+	foreign := encryptAESWithKey("lost-key-secret", []byte("22222222222222222222222222222222"))
+	for i := 0; i < 2; i++ {
+		if _, err := db.Exec(`INSERT INTO remote_nodes (ssh_credential) VALUES (?)`, foreign); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := captureLog(t, migrateLegacyCredentialsIfNeeded)
+	for _, want := range []string{"[CRITICAL]", "2 stored SSH credential(s)", "config/aes.key", "re-entered"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("migration did not report the undecryptable rows (missing %q):\n%s", want, out)
+		}
+	}
+	var stored string
+	if err := db.QueryRow(`SELECT ssh_credential FROM remote_nodes WHERE id=1`).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored != foreign {
+		t.Fatalf("undecryptable row was rewritten: %q", stored)
+	}
+}

--- a/backend/crypto_utils.go
+++ b/backend/crypto_utils.go
@@ -90,6 +90,7 @@ func migrateLegacyCredentialsIfNeeded() {
 		enc string
 	}
 	var updates []update
+	undecryptable := 0
 	for rows.Next() {
 		var id int64
 		var cred string
@@ -110,8 +111,10 @@ func migrateLegacyCredentialsIfNeeded() {
 			plain, ok = decryptAESCore(cred, legacyAESKey)
 		}
 		if !ok {
-			// Not decryptable with either key (e.g. foreign/malformed):
-			// preserve the value verbatim instead of corrupting it.
+			// Not decryptable with either key: preserve the value verbatim
+			// instead of corrupting it, but count it — a whole table of these
+			// means the per-install key was replaced out from under the data.
+			undecryptable++
 			continue
 		}
 		if enc := encryptAESWithKey(plain, aesKey); enc != cred {
@@ -150,6 +153,15 @@ func migrateLegacyCredentialsIfNeeded() {
 		// an interrupted migration is retried on the next boot.
 		_ = os.Remove(rotationPendingPath())
 		log.Printf("[SECURITY] key rotation completed")
+	}
+
+	if undecryptable > 0 {
+		// Silent preservation is right for the data; it is wrong for the
+		// operator, who would otherwise first learn of this when a deploy
+		// fails to authenticate. The usual cause is config/aes.key being
+		// replaced — historically by "git reset --hard" in update.sh, back
+		// when the file was tracked.
+		log.Printf("[CRITICAL] %d stored SSH credential(s) cannot be decrypted with the current or legacy key and were left untouched; the per-install key in config/aes.key was most likely replaced (an older update.sh ran git reset --hard over it). Those nodes need their SSH credentials re-entered.", undecryptable)
 	}
 }
 

--- a/config/aes.key
+++ b/config/aes.key
@@ -1,1 +1,0 @@
-proxygw-secret-key-32-bytes-long

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -45,9 +45,24 @@ echo "[1/4] Pulling latest changes..."
 # Keep git transport direct/SSH and isolated from local HTTP/SOCKS proxy variables.
 # This avoids GnuTLS handshake failures when the update script runs on the proxy gateway itself.
 # Force tag sync to tolerate locally stale tags when stable tag is re-pointed (e.g. v1.6.1)
+# config/aes.key is generated on first boot and is the only copy of the key
+# every stored SSH credential is encrypted with. It used to be a tracked file,
+# so "git reset --hard" below replaced it with the committed placeholder and
+# every credential became undecryptable on the next start. Carry it across
+# the reset regardless of what the tree says about it.
+AES_KEY_BACKUP=""
+if [ -f "$REPO_DIR/config/aes.key" ]; then
+    AES_KEY_BACKUP=$(mktemp)
+    cp -p "$REPO_DIR/config/aes.key" "$AES_KEY_BACKUP"
+fi
 env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY git fetch --force origin --tags
 env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY git reset --hard origin/main
 git clean -fd
+if [ -n "$AES_KEY_BACKUP" ]; then
+    mkdir -p "$REPO_DIR/config"
+    cp -p "$AES_KEY_BACKUP" "$REPO_DIR/config/aes.key"
+    rm -f "$AES_KEY_BACKUP"
+fi
 # Hard sync + clean to tolerate local generated/dirty files (geodata, binaries, etc.)
 
 echo "[2/4] Downloading backend from GitHub Releases..."


### PR DESCRIPTION
## The bug

`config/aes.key` is a **tracked file**, committed 2026-04-18, and its content is the legacy placeholder constant from `crypto_utils.go`:

```
$ git show origin/main:config/aes.key
proxygw-secret-key-32-bytes-long
```

That interacts with two pieces of existing behaviour:

1. On first boot `init()` sees the constant, rotates to a random key, and writes it back to the same path. git now sees a modified tracked file. (Verified on a live gateway: local `18dba73f…`, HEAD `df695e20…`.)
2. `update.sh` runs `git reset --hard origin/main` before installing the new binary. That **puts the placeholder back over the rotated key.**

Next start: `init()` sees the constant again → rotates to a *new* random key → the migration pass tries the legacy constant against rows encrypted with the *previous* random key → fails → leaves them untouched (which is the right call for the data). Every remote node's SSH credential is now permanently undecryptable, and nothing says so until a deploy or health-check fails to authenticate.

**Every run of `update.sh` has been silently discarding every stored SSH credential.**

## The fix

- `git rm --cached config/aes.key`; ignore it and `config/aes.rotation_pending`.
- `update.sh` copies `config/aes.key` aside before `git reset --hard` and restores it after, so the file survives regardless of what the tree says about it.
- When the migration pass finds rows it cannot open with either key, it now logs `[CRITICAL]` with the count, the likely cause, and the remedy — instead of preserving them in silence. The rows are still preserved.

## What this cannot fix

An existing install upgrading to this version still executes the **old** `update.sh`, whose `git reset --hard` runs before the new script exists on disk — and with `aes.key` now untracked, that reset *deletes* it. That one upgrade cannot be protected from the repository side. The changelog for the next release carries a loud pre-upgrade note: `cp -p /root/proxygw/config/aes.key /root/aes.key.bak` first; if the `[CRITICAL]` line appears afterwards, copy it back and restart `proxygw`. I will verify both the failure and the recovery on the test gateway before releasing.

## Related, not changed here

`core/xray/xray` (36 MB), `core/xray/xray.bak` (36 MB) and `core/mosdns/mosdns` (19 MB) are also tracked, and the daily "auto-update Xray, Mosdns" workflow commits new builds of them. `git reset --hard` in `update.sh` is therefore *how* hosts receive core-binary updates, so untracking them is a distribution-model change rather than a bug fix. Worth a separate discussion: 92 MB of binaries in git history, and a host that upgraded Xray via the in-app updater gets rolled back to the committed build on the next `update.sh`.

## Verification

`go build`, `go vet`, `go test ./...` clean. New tests assert the file is ignored, that `update.sh`'s backup/restore actually brackets the reset (position-checked, not just present), and that the migration pass reports undecryptable rows at CRITICAL while leaving them intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
