### PR TITLE
scripts: stop db_optimize.sh printing a Parse error on every upgrade

### DIFF
--- a/scripts/db_optimize.sh
+++ b/scripts/db_optimize.sh
@@ -62,16 +62,22 @@ stat -c '%n %s bytes' "$BACKUP"
 prune_old_backups "$BACKUP_KEEP"
 
 printf '\n[STEP] Create/refresh indexes\n'
-sqlite3 "$DB_PATH" <<'SQL'
-CREATE INDEX IF NOT EXISTS idx_dgl_domain_resolver_ver
-ON domain_geoip_lock(domain, resolver_group, geodata_ver);
-
-CREATE INDEX IF NOT EXISTS idx_gateway_events_module_level_id
-ON gateway_events(module, level, id DESC);
-
-ANALYZE;
-PRAGMA optimize;
-SQL
+# domain_geoip_lock is created lazily by the backend (ospf_geoip_lock.go) the
+# first time Mode C locks a GeoIP tag. On a host that has never done that it
+# does not exist, and the CREATE INDEX for it fails with "no such table".
+# sqlite3 carries on, so the other index was still built — but every upgrade
+# printed a Parse error for something that is not a problem. Only touch it
+# when it is there.
+table_exists() {
+  [ "$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='$1';")" = "1" ]
+}
+if table_exists domain_geoip_lock; then
+  sqlite3 "$DB_PATH" "CREATE INDEX IF NOT EXISTS idx_dgl_domain_resolver_ver ON domain_geoip_lock(domain, resolver_group, geodata_ver);"
+else
+  echo "[SKIP] domain_geoip_lock not present yet (created on first Mode C GeoIP lock); its index is deferred"
+fi
+sqlite3 "$DB_PATH" "CREATE INDEX IF NOT EXISTS idx_gateway_events_module_level_id ON gateway_events(module, level, id DESC);"
+sqlite3 "$DB_PATH" "ANALYZE; PRAGMA optimize;"
 
 if [[ "$MODE" == "--full" ]]; then
   printf '\n[STEP] VACUUM (may take time and hold write lock)\n'
@@ -85,7 +91,9 @@ sqlite3 "$DB_PATH" "PRAGMA page_size; PRAGMA page_count; PRAGMA freelist_count; 
   | awk 'NR==1{print "page_size=" $1} NR==2{print "page_count=" $1} NR==3{print "freelist_count=" $1} NR==4{print "journal_mode=" $1} NR==5{print "synchronous=" $1} NR==6{print "auto_vacuum=" $1}'
 
 printf '\n[STEP] Query plan check\n'
-sqlite3 "$DB_PATH" "EXPLAIN QUERY PLAN SELECT geoip_tag FROM domain_geoip_lock WHERE domain='example.com' AND resolver_group='direct' AND geodata_ver='v1';"
+if table_exists domain_geoip_lock; then
+  sqlite3 "$DB_PATH" "EXPLAIN QUERY PLAN SELECT geoip_tag FROM domain_geoip_lock WHERE domain='example.com' AND resolver_group='direct' AND geodata_ver='v1';"
+fi
 sqlite3 "$DB_PATH" "EXPLAIN QUERY PLAN SELECT id,module,level,ts FROM gateway_events WHERE module='ospf' AND level='info' ORDER BY id DESC LIMIT 50;"
 
 printf '\n[DONE] Backup: %s\n' "$BACKUP"


### PR DESCRIPTION
Seen while verifying the v1.7.27 upgrade path on a live gateway:

```
[STEP] Create/refresh indexes
Parse error near line 1: no such table: main.domain_geoip_lock
Update Complete!
```

`domain_geoip_lock` is created lazily by `ospf_geoip_lock.go` the first time Mode C locks a GeoIP tag, so on a host that has never done that the `CREATE INDEX` for it fails. `sqlite3` does not `-bail`, so the `gateway_events` index was still built and the update completed — but every upgrade printed an error for a non-problem, right in the middle of a flow where operators are looking for real ones.

Create that index (and run its query-plan check) only when the table exists; print a `[SKIP]` line otherwise.

Reproduced against a copy of a live database that lacks the table: old script → Parse error; new script → `[SKIP]`, remaining index built. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)