### PR TITLE
fix: retry route publishing shortly after startup instead of waiting for the ticker

### DIFF
--- a/backend/cron_domain_service.go
+++ b/backend/cron_domain_service.go
@@ -185,7 +185,32 @@ func scheduleApplyWithMosdns(needMosdns bool) {
 	})
 }
 
+// startupRouteSyncBackoff is how long domainIPUpdater waits before each of
+// its early syncs after the process starts. The first sync after a restart
+// is kicked by applyXrayConfig, and it runs while Xray and Mosdns are still
+// coming up: dig gets no answer (exit 9), nothing is published, and nothing
+// retried until the five-minute ticker. update.sh and flush_cache.sh both
+// wipe routes_table before restarting, so every upgrade in Mode B or C left
+// the main router without routes for up to five minutes. A short burst of
+// retries converges within about a minute instead. Package-level so tests
+// can shrink it.
+var startupRouteSyncBackoff = []time.Duration{15 * time.Second, 45 * time.Second, 2 * time.Minute}
+
+// startupRouteSyncBurst schedules a sync after each backoff step while the
+// gateway is in a publishing mode. scheduleStaticRouteSync coalesces, so a
+// burst that overlaps the ticker or a mode switch costs nothing extra.
+func startupRouteSyncBurst() {
+	for _, d := range startupRouteSyncBackoff {
+		time.Sleep(d)
+		if mode := currentMode(); mode == "B" || mode == "C" {
+			scheduleStaticRouteSync(mode)
+		}
+	}
+}
+
 func domainIPUpdater() {
+	startupRouteSyncBurst()
+
 	ticker := time.NewTicker(5 * time.Minute)
 	for range ticker.C {
 		var mode string

--- a/backend/startup_route_sync_test.go
+++ b/backend/startup_route_sync_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// After a restart the first sync is kicked while Xray and Mosdns are still
+// starting, resolves nothing, and — before this — nothing tried again until
+// the five-minute ticker. Both update.sh and flush_cache.sh wipe routes_table
+// and restart, so every upgrade in Mode B or C left the main router without
+// routes for that long. The burst has to fire for both publishing modes and
+// stay quiet for Mode A.
+func TestStartupRouteSyncBurstFiresForPublishingModes(t *testing.T) {
+	setupFeatureSuiteRouter(t)
+
+	oldBackoff := startupRouteSyncBackoff
+	oldSync := syncStaticRoutesToOSPFFunc
+	startupRouteSyncBackoff = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() {
+		startupRouteSyncBackoff = oldBackoff
+		syncStaticRoutesToOSPFFunc = oldSync
+		waitStaticRouteSyncIdle(t)
+	})
+
+	for _, tc := range []struct {
+		mode     string
+		wantSync bool
+	}{
+		{"C", true},
+		{"B", true},
+		{"A", false},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			waitStaticRouteSyncIdle(t)
+			if _, err := db.Exec("INSERT OR REPLACE INTO settings(key, value) VALUES ('mode', ?)", tc.mode); err != nil {
+				t.Fatal(err)
+			}
+			got := make(chan string, 8)
+			syncStaticRoutesToOSPFFunc = func(mode string) { got <- mode }
+
+			startupRouteSyncBurst()
+
+			select {
+			case m := <-got:
+				if !tc.wantSync {
+					t.Fatalf("mode %s: startup burst scheduled a sync it should not have", tc.mode)
+				}
+				if m != tc.mode {
+					t.Fatalf("sync ran for %q, want %q", m, tc.mode)
+				}
+			case <-time.After(500 * time.Millisecond):
+				if tc.wantSync {
+					t.Fatalf("mode %s: startup burst never scheduled a sync; the main router would wait for the ticker", tc.mode)
+				}
+			}
+		})
+	}
+}
+
+// The production backoff has to actually be short: the whole point is to
+// beat the five-minute ticker by a wide margin.
+func TestStartupRouteSyncBackoffConvergesWellBeforeTheTicker(t *testing.T) {
+	var total time.Duration
+	for _, d := range startupRouteSyncBackoff {
+		total += d
+	}
+	if len(startupRouteSyncBackoff) < 2 {
+		t.Fatalf("burst has %d step(s); one attempt cannot cover a service that is still starting", len(startupRouteSyncBackoff))
+	}
+	if startupRouteSyncBackoff[0] > 30*time.Second {
+		t.Fatalf("first retry at %v is too late to be a startup burst", startupRouteSyncBackoff[0])
+	}
+	if total >= 5*time.Minute {
+		t.Fatalf("burst spans %v, which is no better than the ticker it exists to beat", total)
+	}
+}


### PR DESCRIPTION
## The gap

#35 made a **mode switch** publish routes immediately. A **restart** still does not.

After a restart the first OSPF sync is kicked by `applyXrayConfig` (`xray_service.go:452`) while Xray and Mosdns are still coming up, so `dig` gets no answer:

```
[OSPF] domain "www.google.com" (proxy) resolve failed: resolve www.google.com failed: dig execution failed: exit status 9
```

Nothing is published, and nothing tries again until `domainIPUpdater`'s five-minute ticker. That matters more than it sounds, because `update.sh` step 4/5 and `flush_cache.sh` both run `DELETE FROM routes_table` and then restart — so **every upgrade in Mode B or C leaves the main router without routes for up to five minutes**, and the reconcile loop even prunes the FRR side in the meantime:

```
[OSPF] reconcile pruned FRR orphan tagged routes in mode C: 8
```

Measured on a live gateway right after the v1.7.27 `update.sh`: `routes_table` empty at 05:34:33, main router at 0 OSPF routes, a client's traffic bypassing the gateway; republished by the ticker at 05:39:40.

## The change

`domainIPUpdater` now runs a short burst before entering its ticker loop: a sync at +15s, +45s and +2m, for Mode B and C. `scheduleStaticRouteSync` coalesces, so overlapping the ticker or a mode switch costs nothing extra. The ticker is unchanged. Mode A stays quiet.

## Verification

`go build`, `go vet`, `go test ./...` clean. Tests shrink the backoff to milliseconds and assert the burst schedules a sync for B and C and none for A, and pin that the production backoff really is short (first retry ≤ 30s, total well under the five-minute ticker).

I will verify convergence time on the live gateway once this is in a release: `update.sh` wipes the table, and routes should be back within about a minute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
