### PR TITLE
security: verify the Xray download on remote nodes and pick the right architecture

### DIFF
--- a/backend/remote_deploy/deploy_script.go
+++ b/backend/remote_deploy/deploy_script.go
@@ -194,7 +194,26 @@ else
 fi
 mkdir -p /usr/local/etc/xray
 mkdir -p /usr/local/share/xray
-retry_cmd curl -4 --fail --location --retry 5 --retry-delay 2 --retry-all-errors -H "Cache-Control: no-cache" -o xray.zip https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-64.zip
+# Pick the asset for this host. The script used to hardcode the x86-64 build,
+# which on an arm64 node installed a binary the machine cannot execute.
+case "$(uname -m)" in
+  x86_64|amd64)  XRAY_ASSET="Xray-linux-64.zip" ;;
+  aarch64|arm64) XRAY_ASSET="Xray-linux-arm64-v8a.zip" ;;
+  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+XRAY_BASE="https://github.com/XTLS/Xray-core/releases/latest/download"
+retry_cmd curl -4 --fail --location --retry 5 --retry-delay 2 --retry-all-errors -H "Cache-Control: no-cache" -o xray.zip "$XRAY_BASE/$XRAY_ASSET"
+# XTLS publishes a digest next to every asset. This binary runs as root on the
+# node; verify it before it is unpacked. A mismatch aborts the deploy.
+retry_cmd curl -4 --fail --location --retry 5 --retry-delay 2 --retry-all-errors -H "Cache-Control: no-cache" -o xray.zip.dgst "$XRAY_BASE/$XRAY_ASSET.dgst"
+XRAY_WANT=$(awk '/^SHA2-256=/ {print $2}' xray.zip.dgst)
+XRAY_GOT=$(sha256sum xray.zip | awk '{print $1}')
+if [ -z "$XRAY_WANT" ] || [ "$XRAY_WANT" != "$XRAY_GOT" ]; then
+  echo "Xray download failed verification for $XRAY_ASSET (expected ${XRAY_WANT:-<none>}, got $XRAY_GOT)" >&2
+  rm -f xray.zip xray.zip.dgst
+  exit 1
+fi
+rm -f xray.zip.dgst
 unzip -o xray.zip -d /usr/local/bin/xray-core
 mv /usr/local/bin/xray-core/xray /usr/local/bin/xray
 mv /usr/local/bin/xray-core/geoip.dat /usr/local/share/xray/

--- a/backend/remote_deploy/deploy_script_test.go
+++ b/backend/remote_deploy/deploy_script_test.go
@@ -17,6 +17,15 @@ func TestGenerateVlessRealityInstallScript_UsesRetryablePackageAndDownloadSteps(
 		"net.ipv4.tcp_congestion_control=bbr",
 		"curl -4 --fail --location",
 		"--retry 5",
+		// The Xray binary runs as root on the node: it must be verified
+		// against the digest XTLS publishes, and chosen for the node's own
+		// architecture rather than assumed to be x86-64.
+		`case "$(uname -m)" in`,
+		"Xray-linux-64.zip",
+		"Xray-linux-arm64-v8a.zip",
+		`"$XRAY_BASE/$XRAY_ASSET.dgst"`,
+		"/^SHA2-256=/",
+		"sha256sum xray.zip",
 	}
 	for _, want := range checks {
 		if !strings.Contains(script, want) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -278,6 +278,20 @@ if ! "$REPO_DIR/core/xray/xray" version >/dev/null 2>&1; then
     echo "Downloading Xray for $ARCH..."
     XRAY_URL="https://github.com/XTLS/Xray-core/releases/latest/download/Xray-linux-${XRAY_ARCH}.zip"
     wget -q -4 -O /tmp/xray.zip "$XRAY_URL"
+    # XTLS publishes a digest next to every asset; this binary runs as root.
+    wget -q -4 -O /tmp/xray.zip.dgst "${XRAY_URL}.dgst" || true
+    XRAY_WANT=$(awk '/^SHA2-256=/ {print $2}' /tmp/xray.zip.dgst 2>/dev/null)
+    XRAY_GOT=$(sha256sum /tmp/xray.zip | awk '{print $1}')
+    if [ -z "$XRAY_WANT" ]; then
+        echo "Warning: could not fetch Xray digest; skipping verification"
+    elif [ "$XRAY_WANT" != "$XRAY_GOT" ]; then
+        echo "Error: Xray download failed verification (expected $XRAY_WANT, got $XRAY_GOT)" >&2
+        rm -f /tmp/xray.zip /tmp/xray.zip.dgst
+        exit 1
+    else
+        echo "Xray download verified"
+    fi
+    rm -f /tmp/xray.zip.dgst
     unzip -qo /tmp/xray.zip xray -d "$REPO_DIR/core/xray/"
     rm -f /tmp/xray.zip
 fi


### PR DESCRIPTION
## Two gaps in the remote deploy script

**Unverified download.** `deploy_script.go` fetched `Xray-linux-64.zip` from the `latest` release and unpacked it into `/usr/local/bin` as root with no integrity check. XTLS publishes a `.dgst` next to every asset:

```
MD5= …
SHA1= …
SHA2-256= 23cd9af937744d97776ee35ecad4972cf4b2109d1e0fe6be9930467608f7c8ae
SHA2-512= …
```

The script now fetches it, compares `SHA2-256` against the download, and aborts the deploy on a mismatch. (The in-app updater already verified Xray against a published hash; the shell paths were the exception — same class as #43.)

**Hardcoded architecture.** The asset name was fixed to the x86-64 build. A deploy to an arm64 node installed a binary the machine cannot execute; since #26 that at least fails the smoke test instead of reporting Online, but it should simply work. The asset is now chosen from `uname -m` (`x86_64`/`aarch64`), matching what `install.sh` already does for the gateway.

## Also: `install.sh`

The gateway's own Xray download in `install.sh` was equally unverified. It now fetches the digest and verifies. The digest fetch may fail with a warning (the offline/API-blocked install path already tolerates GitHub being unreachable), but a digest that is present and does not match is fatal.

## Verification

Both `.dgst` URLs confirmed live (HTTP 200) and the format confirmed. Generated script inspected end to end — no `fmt.Sprintf` verb collisions. `go build`, `go vet`, `go test ./...` clean; `deploy_script_test.go` now asserts the arch switch, both asset names, the `.dgst` fetch and the `SHA2-256` comparison. `bash -n scripts/install.sh` clean.

## Note

`latest/download/<asset>` and `latest/download/<asset>.dgst` are two requests; if XTLS publishes a release between them the check fails and the deploy must be retried. That is the safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
